### PR TITLE
Explicitly put in the instructions to pull down the full source code if they want to compile.  If someone looks for a 'configure' script in the binary distro, they won't find it.

### DIFF
--- a/docs/book/installation.tex
+++ b/docs/book/installation.tex
@@ -165,6 +165,11 @@ experience. Some dependencies such as ISIS and its dependencies
 Due to the complex nature of the dependent software, we can't help you 
 with questions about those libraries.
 
+In order to compile and build your own version of Stereo Pipeline you will
+need the full distribution.  The binary distribution that we provide does not
+have the full build tree.  The source code for Stereo Pipeline is available
+from Github at \url{https://github.com/NeoGeographyToolkit/StereoPipeline}.
+
 \subsection{Dependency List}
 
 This is a list of the prime dependencies of Stereo Pipeline. Some libraries


### PR DESCRIPTION
...lation.
