### PR TITLE
libtool-bin needed on Ubuntu ?

### DIFF
--- a/INSTALLGUIDE
+++ b/INSTALLGUIDE
@@ -41,6 +41,7 @@ Python (version >= 2.6.1)
 g++, gfortran (version >= 4.4.7)
 csh
 libtool
+libtool-bin
 autoconf
 automake
 git-core
@@ -59,7 +60,7 @@ freeglut3-dev
 If you have root access on your machine you can install them on a
 Debian-based distribution using the following command:
 
-sudo apt-get install g++ gfortran csh libtool autoconf automake   \
+sudo apt-get install g++ gfortran csh libtool libtool-bin autoconf automake   \
   git-core subversion xserver-xorg-dev xorg-dev libx11-dev        \
   libxext-dev libxmu6 libxmu-dev libxi-dev libgl1-mesa-dev        \
   libglu1-mesa-dev freeglut3-dev


### PR DESCRIPTION
Hi,

I am not sure if that is only the case for Ubuntu (16.04), but when I tried to install after installing packages, I got the message (even though I installed libtool):
ERROR: Missing required executables for building. You need to install ['libtool']

When trying to execute libtool on my machine, I got:
The program 'libtool' is currently not installed. You can install it by typing:
sudo apt install libtool-bin

So I installed libtool-bin. The installation goes further, but it is still not working, I got:

========== Building: libtool ==========
========== libtool.fetch ==========
Failed to build libtool in attempt 0 ''
ERROR: ''

So I am not quite sure this is a solution. Could you give me some directions about this issue ?

Thanks,
