### PR TITLE
Fix clang warnings in ASP.

### DIFF
--- a/src/asp/Core/DemDisparity.h
+++ b/src/asp/Core/DemDisparity.h
@@ -26,7 +26,7 @@
 
 // Forward declaration
 namespace asp {
-  class ASPGlobalOptions;
+  struct ASPGlobalOptions;
 }
 namespace vw {
   namespace camera {

--- a/src/asp/Core/LocalHomography.h
+++ b/src/asp/Core/LocalHomography.h
@@ -27,7 +27,7 @@
 
 // Forward declaration
 namespace asp {
-  class ASPGlobalOptions;
+  struct ASPGlobalOptions;
 }
 
 namespace asp {

--- a/src/asp/Core/PhotometricOutlier.h
+++ b/src/asp/Core/PhotometricOutlier.h
@@ -28,7 +28,7 @@
 // Forward declaration
 namespace vw{
   namespace cartography{
-    class GdalWriteOptions;
+    struct GdalWriteOptions;
   }
 }
 

--- a/src/asp/Core/SoftwareRenderer.h
+++ b/src/asp/Core/SoftwareRenderer.h
@@ -47,7 +47,6 @@ namespace stereo {
       float *m_buffer;
       int m_shadeMode;
       float m_currentFlatColor[3];
-      float m_clearColor[4];
       double m_transformNDC[3][2];
       double m_transformViewport[3][2];
       void *m_graphicsState;

--- a/src/asp/IsisIO/BaseEquation.h
+++ b/src/asp/IsisIO/BaseEquation.h
@@ -41,7 +41,7 @@ namespace asp {
     double m_time_offset;
 
     // Update Cache (m_cached_output)
-    virtual void update ( double const& t ) = 0;
+    virtual void update ( double t ) = 0;
 
   public:
     // Constructor
@@ -49,25 +49,25 @@ namespace asp {
     virtual std::string type() const = 0;
 
     //Evaluates the equation at time T
-    vw::Vector3 evaluate( double const& t ) {
+    vw::Vector3 evaluate( double t ) {
       if ( t != m_cached_time )
         update( t );
       return m_cached_output;
     }
-    vw::Vector3 operator()( double const& t ) { return evaluate(t);}
+    vw::Vector3 operator()( double t ) { return evaluate(t);}
 
     // Tells the number of constants defining the equation
     // This is especially vague as it is meant for interaction with a
     // bundle adjuster. BA just wants to roll through the constants
     // and redefine them.
     virtual size_t size() const = 0;
-    virtual double& operator[]( size_t const& n ) = 0;
-    const double& operator[]( size_t const& n ) const {
-      return this->operator[](n);
+    virtual double& operator[]( size_t n ) = 0;
+    const double& operator[]( size_t n ) const {
+      return const_cast<BaseEquation*>(this)->operator[](n);
     }
 
     // Allows us to set the time offset
-    void set_time_offset( double const& offset ) {
+    void set_time_offset( double offset ) {
       m_cached_time = -1;
       m_time_offset = offset;
     }
@@ -76,7 +76,6 @@ namespace asp {
     // FileIO routines
     virtual void write( std::ofstream &f ) = 0;
     virtual void read( std::ifstream &f ) = 0;
-
   };
 
 

--- a/src/asp/IsisIO/PolyEquation.cc
+++ b/src/asp/IsisIO/PolyEquation.cc
@@ -69,7 +69,7 @@ PolyEquation::PolyEquation( int order_x,
 
 // Update
 //-----------------------------------------------
-void PolyEquation::update( double const& t ) {
+void PolyEquation::update( double t ) {
   m_cached_time = t;
   double delta_t = t-m_time_offset;
   Vector<double> powers( m_max_length );
@@ -149,15 +149,15 @@ void PolyEquation::read( std::ifstream& f ) {
 
 // Constant Access
 //-----------------------------------------------
-double& PolyEquation::operator[]( size_t const& n ) {
+double& PolyEquation::operator[]( size_t n ) {
   m_cached_time = -1;
-  if ( n >= m_x_coeff.size()+m_y_coeff.size()+m_z_coeff.size() )
-    vw_throw( ArgumentErr() << "PolyEquation: invalid index.");
-  if ( n < m_x_coeff.size() ) {
+  if (n >= m_x_coeff.size() + m_y_coeff.size() + m_z_coeff.size())
+    vw_throw(ArgumentErr() << "PolyEquation: invalid index.");
+  if (n < m_x_coeff.size()) {
     return m_x_coeff[n];
-  } else if ( n < m_x_coeff.size()+m_y_coeff.size() ) {
-    return m_y_coeff[n-m_x_coeff.size()];
+  } else if (n < m_x_coeff.size() + m_y_coeff.size()) {
+    return m_y_coeff[n - m_x_coeff.size()];
   } else {
-    return m_z_coeff[n-m_x_coeff.size()-m_y_coeff.size()];
+    return m_z_coeff[n - m_x_coeff.size() - m_y_coeff.size()];
   }
 }

--- a/src/asp/IsisIO/PolyEquation.h
+++ b/src/asp/IsisIO/PolyEquation.h
@@ -31,13 +31,13 @@ namespace asp {
     vw::Vector<double> m_z_coeff;
     vw::uint8 m_max_length; // Maximum order + 1
 
-    void update ( double const& t );
+    void update ( double t );
   public:
     PolyEquation( int order = 0 );
     PolyEquation( int, int, int );
-    PolyEquation( vw::Vector<double>& x,
-                  vw::Vector<double>& y,
-                  vw::Vector<double>& z ) : m_x_coeff(x), m_y_coeff(y), m_z_coeff(z) {
+    PolyEquation(vw::Vector<double> const& x, vw::Vector<double> const& y,
+                 vw::Vector<double> const& z)
+        : m_x_coeff(x), m_y_coeff(y), m_z_coeff(z) {
       m_cached_time = -1;
       m_time_offset = 0;
       if ( x.size() > 254 || y.size() > 254 || z.size() > 254 )
@@ -48,7 +48,7 @@ namespace asp {
     std::string type() const {  return "PolyEquation"; }
 
     size_t size() const { return m_x_coeff.size()+m_y_coeff.size()+m_z_coeff.size(); }
-    double& operator[]( size_t const& n );
+    double& operator[]( size_t n );
 
     void write( std::ofstream &f );
     void read( std::ifstream &f );

--- a/src/asp/IsisIO/RPNEquation.cc
+++ b/src/asp/IsisIO/RPNEquation.cc
@@ -41,9 +41,9 @@ RPNEquation::RPNEquation() {
   m_cached_time = -1;
   m_time_offset = 0;
 }
-RPNEquation::RPNEquation( std::string x_eq,
-                          std::string y_eq,
-                          std::string z_eq ) {
+RPNEquation::RPNEquation( std::string const& x_eq,
+                          std::string const& y_eq,
+                          std::string const& z_eq ) {
   string_to_eqn( x_eq, m_x_eq, m_x_consts );
   string_to_eqn( y_eq, m_y_eq, m_y_consts );
   string_to_eqn( z_eq, m_z_eq, m_z_consts );
@@ -53,7 +53,7 @@ RPNEquation::RPNEquation( std::string x_eq,
 
 // Update
 //-----------------------------------------------------
-void RPNEquation::update( double const& t ) {
+void RPNEquation::update( double t ) {
   m_cached_time = t;
   double delta_t = t - m_time_offset;
   m_cached_output[0] = evaluate( m_x_eq,
@@ -66,7 +66,7 @@ void RPNEquation::update( double const& t ) {
                                  m_z_consts,
                                  delta_t );
 }
-void RPNEquation::string_to_eqn( std::string& str,
+void RPNEquation::string_to_eqn( std::string const& str,
                                  std::vector<std::string>& commands,
                                  std::vector<double>& consts ) {
   // Breaks a string into the equation format used internally
@@ -92,16 +92,17 @@ void RPNEquation::string_to_eqn( std::string& str,
     }
   }
 }
-double RPNEquation::evaluate( std::vector<std::string>& commands,
+
+double RPNEquation::evaluate( std::vector<std::string> const& commands,
                               std::vector<double>& consts,
-                              double const& t ) {
+                              double t ) {
   // Evaluates an equation in the internal format
   if ( commands.empty() )
     return 0;
   int consts_index = 0;
   std::stack<double> rpn_stack;
   double buffer;
-  for ( std::vector<std::string>::iterator iter = commands.begin();
+  for ( std::vector<std::string>::const_iterator iter = commands.begin();
         iter != commands.end(); ++iter ) {
     if ( *iter == "c" ) {
       rpn_stack.push( consts[consts_index] );
@@ -205,24 +206,27 @@ void RPNEquation::write( std::ofstream &f ) {
     f << "\n";
   }
 }
+
 void RPNEquation::read( std::ifstream &f ) {
   std::string buffer;
   m_cached_time = -1;
 
-  buffer = "";
+  buffer.clear();
   std::getline( f, buffer );
   string_to_eqn( buffer, m_x_eq, m_x_consts );
-  buffer = "";
+
+  buffer.clear();
   std::getline( f, buffer );
   string_to_eqn( buffer, m_y_eq, m_y_consts );
-  buffer = "";
+
+  buffer.clear();
   std::getline( f, buffer );
   string_to_eqn( buffer, m_z_eq, m_z_consts );
 }
 
 // Constant Access
 //-----------------------------------------------------
-double& RPNEquation::operator[]( size_t const& n ) {
+double& RPNEquation::operator[]( size_t n ) {
   m_cached_time = -1;
   if ( n >= m_x_consts.size() + m_y_consts.size()
        + m_z_consts.size() )

--- a/src/asp/IsisIO/RPNEquation.h
+++ b/src/asp/IsisIO/RPNEquation.h
@@ -46,23 +46,23 @@ namespace asp {
     std::vector<std::string> m_z_eq;
     std::vector<double> m_z_consts;
 
-    void update( double const& t );
-    void string_to_eqn( std::string& str,
+    void update( double t );
+    void string_to_eqn( std::string const& str,
                         std::vector<std::string>& commands,
                         std::vector<double>& consts );
-    double evaluate( std::vector<std::string>& commands,
+    double evaluate( std::vector<std::string> const& commands,
                      std::vector<double>& consts,
-                     double const& t );
+                     double t );
   public:
     RPNEquation();
-    RPNEquation( std::string x_eq,
-                 std::string y_eq,
-                 std::string z_eq );
+    RPNEquation( std::string const& x_eq,
+                 std::string const& y_eq,
+                 std::string const& z_eq );
     std::string type() const { return "RPNEquation"; }
 
     size_t size() const { return m_x_consts.size() +
         m_y_consts.size() + m_z_consts.size(); }
-    double& operator[]( size_t const& n );
+    double& operator[]( size_t n );
 
     void write( std::ofstream &f );
     void read( std::ifstream &f );


### PR DESCRIPTION
We had one unused variable and several structs accidentally forward
declared as classes.

In BaseEquation(), clang was confused and saw an infinite loop in
operator[]. That was fixed with a const_cast.

Finally, don't pass POD types with a const&. POD types are the same size
as a pointer so it's faster to just copy the POD type. See the first
comment of:
https://stackoverflow.com/questions/7561690/why-do-we-not-pass-pod-by-reference-in-functions

The internal C++ guide for Google also complains about this.
Unfortunately their public style guide doesn't mention it. :/