### PR TITLE
Clean up Python stderr print statements

### DIFF
--- a/src/asp/Python/asp_system_utils.py
+++ b/src/asp/Python/asp_system_utils.py
@@ -21,7 +21,6 @@
 General system related utilities
 """
 
-from __future__ import print_function
 import sys, os, re, shutil, subprocess, string, time, errno, multiprocessing, signal
 import os.path as P
 import asp_string_utils, asp_cmd_utils

--- a/src/asp/Tools/cam2map4stereo.py
+++ b/src/asp/Tools/cam2map4stereo.py
@@ -17,7 +17,6 @@
 # __END_LICENSE__
 
 
-from __future__ import print_function
 import os, optparse, subprocess, sys, tempfile
 
 # The path to the ASP python files.
@@ -261,7 +260,6 @@ def main():
 
     except Usage as err:
         print (err.msg, file=sys.stderr)
-        # print >>sys.stderr, "for help use --help"
         return 2
 
     except MapExists as e:

--- a/src/asp/Tools/dg_mosaic
+++ b/src/asp/Tools/dg_mosaic
@@ -562,7 +562,7 @@ def run_cmd( cmd, options ):
         raise Exception('ProcessError', 'Non zero return code ('+str(code)+')')
 
 def die(msg, code=-1):
-    print >>sys.stderr, msg
+    print(msg, file=sys.stderr)
     sys.exit(code)
 
 def scale_xml_element(elem, scale):
@@ -1073,7 +1073,7 @@ def main():
                 run_cmd( cmd, options )
 
     except Usage as err:
-        print >>sys.stderr, err.msg
+        print(err.msg, file=sys.stderr)
         return 2
 
 if __name__ == "__main__":

--- a/src/asp/Tools/hiedr2mosaic.py
+++ b/src/asp/Tools/hiedr2mosaic.py
@@ -16,7 +16,6 @@
 #  limitations under the License.
 # __END_LICENSE__
 
-from __future__ import print_function
 import os, glob, optparse, re, shutil, subprocess, sys, string
 
 try:

--- a/src/asp/Tools/lronac2mosaic.py
+++ b/src/asp/Tools/lronac2mosaic.py
@@ -33,8 +33,8 @@ job_pool = [];
 outputFolder = ""
 
 def man(option, opt, value, parser):
-    print >>sys.stderr, parser.usage
-    print >>sys.stderr, '''\
+    print(parser.usage, file=sys.stderr)
+    print('''\
 This program operates on LRO (.IMG) files, and performs the
 following ISIS 3 operations:
  * Converts to ISIS format (lronac2isis)
@@ -46,6 +46,7 @@ following ISIS 3 operations:
  * Mosaics individual CCDs into one unified image file (handmos)
  * Normalizes the mosaic (cubenorm)
 '''
+    file=sys.stderr)
 
     sys.exit()
 
@@ -491,7 +492,7 @@ def main():
         return 0
 
     except Usage as err:
-        print >>sys.stderr, err.msg
+        print(err.msg, file=sys.stderr)
         return 2
 
     # To more easily debug this program, comment out this catch block.

--- a/src/asp/Tools/runWithLog.py
+++ b/src/asp/Tools/runWithLog.py
@@ -31,7 +31,7 @@ timeStr = datetime.datetime.now().strftime('%Y%m%d_%H%M%S_%f')
 cmdArgv = fullCmd.split(' ')
 cmdShort = os.path.splitext(os.path.basename(cmdArgv[0]))[0]
 logFname = '%s/%s_%s.txt' % (logDir, timeStr, cmdShort)
-print >>sys.stderr, '%s: logging to %s' % (sys.argv[0], logFname)
+print('%s: logging to %s' % (sys.argv[0], logFname), file=sys.stderr)
 
 # open log
 if not os.path.exists(logDir):
@@ -47,7 +47,7 @@ os.dup2(logFile.fileno(), 1)
 os.dup2(logFile.fileno(), 2)
 
 quotedArgs = ['"%s"' % arg for arg in cmdArgv]
-print >>sys.stderr, '%s: running: %s' % (sys.argv[0], ' '.join(quotedArgs))
+print('%s: running: %s' % (sys.argv[0], ' '.join(quotedArgs)), file=sys.stderr)
 
 # run desired command
 os.execvp(cmdArgv[0], cmdArgv)

--- a/src/asp/Tools/sparse_disp
+++ b/src/asp/Tools/sparse_disp
@@ -26,10 +26,9 @@
 # there is high resolution detail such as ice and snow patterns but no low
 # resolution detail.
 
-
 import sys, optparse, subprocess, re, os, math, time, datetime
 def die(msg, code=-1):
-    print >>sys.stderr, msg
+    print(msg, file=sys.stderr)
     sys.exit(code)
 
 # The path to the ASP python files

--- a/src/asp/Tools/time_trials
+++ b/src/asp/Tools/time_trials
@@ -41,7 +41,7 @@ def main():
         if not args: raise Exception('No input command')
 
     except optparse.OptionError as msg:
-        print >>sys.stderr, msg
+        print(msg, file=sys.stderr)
         return 2
 
     print("Running command: [%s]" % args[0])


### PR DESCRIPTION
Update lingering 'print >>sys.stderr, str' commands, which won't work in Python3.

I also removed 'from __future__ import print_function' statements, as I think ASP has dropped support for older versions of Python2.  The future import statements were only present in a handful of the Python tools, so if we want to include, should add to all Python code with print function calls.