### PR TITLE
fix bug with float type conversion in number of interest points

### DIFF
--- a/src/asp/Tools/historical_helper.py
+++ b/src/asp/Tools/historical_helper.py
@@ -74,7 +74,7 @@ def parseInterestPoints(ipString):
     parts = ipString.split()
     if len(parts) % 2 == 1:
         raise Exception('The number of IP numbers must be even!')
-    numIp = len(parts) / 2
+    numIp = int(len(parts) / 2)
 
     ip = np.ndarray(shape=(numIp,2), dtype=float)
 


### PR DESCRIPTION
Please review this easy one line fix, divide by 2 was converting the numip to float (python 3.6)