### PR TITLE
Add a --ssh argument to parallel_stereo to select ssh path.

### DIFF
--- a/src/asp/Tools/parallel_stereo
+++ b/src/asp/Tools/parallel_stereo
@@ -435,6 +435,8 @@ def spawn_to_nodes(step, settings, args):
 
     if opt.nodes_list is not None:
         cmd += ['--sshloginfile', opt.nodes_list]
+    if opt.ssh is not None:
+        cmd += ['--ssh', opt.ssh]
 
     # Add the options which we want GNU parallel to not mess up
     # with. Put them into a single string. Before that, put in quotes
@@ -562,6 +564,8 @@ if __name__ == '__main__':
     p.add_option('--nodes-list',           dest='nodes_list', default=None,
                  help='The list of computing nodes, one per line. ' + \
                  'If not provided, run on the local machine.')
+    p.add_option('--ssh',                  dest='ssh', default=None,
+                 help='The path to ssh program to use to connect to other nodes')
     p.add_option('--processes',            dest='processes', default=None,
                  type='int', help='The number of processes to use per node.')
     p.add_option('--threads-multiprocess', dest='threads_multi', default=None,


### PR DESCRIPTION
Hello,

First of all, thanks for writing, distributing and maintaining ASP!

Using ASP to process a lot of Martian data on a cluster powered by the OAR batch scheduler, the node connection program is a ssh-like (reallly ssh renamed) program called oarsh. In that case, it would be super useful if parallel_stereo would offer an option to select the ssh program to be then passed to gnu parallel.

Would something like this pull request be possible?

Thanks,

-- Matthieu