### PR TITLE
Change `check_system_memory` call for parallel_stereo.

### DIFF
--- a/src/asp/Tools/parallel_stereo
+++ b/src/asp/Tools/parallel_stereo
@@ -53,14 +53,18 @@ skip_symlink_expr = '^.*?-(PC\.tif|RD\.tif|log.*?\.txt)$'
 
 def check_system_memory(opt, args, settings):
     '''Issue a warning if our selected options are estimated to exceed available RAM.'''
+    kb_bytes = 1024
 
     try:
         # Currently only SGM/MGM have large memory requirements.
         if (settings['stereo_algorithm'][0] == VW_CORRELATION_BM):
             return
 
-        # Use a command line call to Estimate the amount of free memory
-        freemem_mb = map(int, os.popen('free -m').readlines()[-2].split()[1:])[2]
+        # Use '/proc/meminfo' to access current memory usage
+        with open('/proc/meminfo') as file:
+            freemem_mb = int(
+                int(file.readlines()[1].split()[1]) / kb_bytes
+            )
 
         # This is the processor count code, won't work if other
         #  machines have a different processor count.
@@ -69,7 +73,7 @@ def check_system_memory(opt, args, settings):
             num_procs = get_num_cpus()
 
         # Memory usage calculations
-        bytes_per_mb        = 1024*1024
+        bytes_per_mb        = kb_bytes * kb_bytes
         est_bytes_per_pixel = 8 # This is a very rough estimate!
 
         num_tile_pixels = pow(int(settings['corr_tile_size'][0]),2)

--- a/src/asp/Tools/parallel_stereo
+++ b/src/asp/Tools/parallel_stereo
@@ -84,10 +84,10 @@ def check_system_memory(opt, settings):
 
         if (est_ram_usage > freemem_mb):
             print('Warning: Estimated maximum memory consumption is '
-                  + str(est_ram_usage) + 'mb but only ' + str(freemem_mb)
-                  + 'mb of free memory is detected.  To lower memory use, '
-                  + 'consider reducing the number of processes or lowering '
-                  + '--corr_memory_limit_mb')
+                  + str(est_ram_usage) + 'mb but only ' + str(freemem_mb) +
+                  'mb of free memory is detected.  To lower memory use, '
+                  'consider reducing the number of processes or lowering '
+                  '--corr_memory_limit_mb')
 
     except:
         # Don't let an error here prevent the tool from running.

--- a/src/asp/Tools/parallel_stereo
+++ b/src/asp/Tools/parallel_stereo
@@ -51,7 +51,7 @@ os.environ["PATH"] = libexecpath + os.pathsep + os.environ["PATH"]
 skip_symlink_expr = '^.*?-(PC\.tif|RD\.tif|log.*?\.txt)$'
 
 
-def check_system_memory(opt, args, settings):
+def check_system_memory(opt, settings):
     '''Issue a warning if our selected options are estimated to exceed available RAM.'''
     kb_bytes = 1024
 
@@ -722,8 +722,7 @@ if __name__ == '__main__':
                             str(corr_tile_size) + ' ' + str(opt.job_size_h) + ' ' + \
                             str(opt.job_size_w) + '.')
 
-
-    check_system_memory(opt, args, settings)
+    check_system_memory(opt, settings)
 
     if opt.tile_id is None:
 


### PR DESCRIPTION
Change querying the available memory for parallel stereo by using the
information from '/proc/meminfo' instead of the `free` command line
call. The latter threw an error on Pleiades and using the proc
information is also in line with `Common.cc#397`.

This will still only work on Linux machines.

