### PR TITLE
mapproject: switch gdalbuildvrt command to subprocess.call()

### DIFF
--- a/src/asp/Tools/mapproject
+++ b/src/asp/Tools/mapproject
@@ -445,8 +445,10 @@ def main(argsIn):
     # Build a gdal VRT file which is composed of all the processed tiles
     vrtPath = os.path.join(tempFolder, 'mosaic.vrt')
     cmd = "gdalbuildvrt -resolution highest " + vrtPath + " " + " ".join(tiles)
-    print(cmd)
-    os.system(cmd)
+    ret = subprocess.call(["gdalbuildvrt", "-resolution", "highest", vrtPath]+tiles)
+    if ret != 0:
+        print("gdalbuildvrt error ", ret)
+        exit(1)
 
     # Modify the vrt to append some metadata from the original tiles
     if not options.noGeoHeaderInfo:


### PR DESCRIPTION
Hi, I had an issue with mapproject and some big HiRISE imagery...

os.system() can be a bit limited, such as when dealing with *lots* of tiles and fail silently due to subshell issues. subprocess.call() (with shell=False) is better at this and fails with more understandable messages if needed.

Here's a proposed fix, would you consider integrating it?

Thanks for all your work!