### PR TITLE
updated hiedr2mosaic to not remove flat files if the keep flag is true

### DIFF
--- a/src/asp/Tools/hiedr2mosaic.py
+++ b/src/asp/Tools/hiedr2mosaic.py
@@ -239,7 +239,7 @@ def noproj( CCD_object, threads, delete=False ):
     return CCDs( noproj_CCDs, CCD_object.match )
 
 # Check for failure for hijitreg.  Sometimes bombs?  Default to zeros.
-def hijitreg( noproj_CCDs, threads ):
+def hijitreg( noproj_CCDs, threads, delete=False ):
     for i in noproj_CCDs.keys():
         j = i + 1
         if( j not in noproj_CCDs ): continue
@@ -256,7 +256,8 @@ def hijitreg( noproj_CCDs, threads ):
         if( j not in noproj_CCDs ): continue
         flat_file = 'flat_'+str(i)+'_'+str(j)+'.txt'
         averages[i] = read_flatfile( flat_file )
-        os.remove( flat_file )
+        if delete:
+            os.remove( flat_file )
 
     return averages
 
@@ -440,7 +441,7 @@ def main():
         noprojed_CCDs = noproj( CCD_files, options.threads, options.delete )
 
         # hijitreg
-        averages = hijitreg( noprojed_CCDs, options.threads )
+        averages = hijitreg( noprojed_CCDs, options.threads, options.delete )
 
         # mosaic handmos
         mosaicked = mosaic( noprojed_CCDs, averages )


### PR DESCRIPTION
## Description
changes hiedr2mosaic.py to retain (not remove) output files from hijitreg calls. 

## Related Issue
none

## Motivation and Context
I wanted to inspect the flat files/replicate some jitter plots for hirise images I have seen out there that I believe are directly produced from these files. For a more complete way to debug hiedr2mosaic it makes sense to keep these files anyways, so it looks like this was just an oversight.

## How Has This Been Tested?
nope but I doubt anything is wrong with it

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
doesn't look like anything from the checklist applies

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).
<!-- Remove the statement that does not apply. -->
- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to the StereoPipeline! -->
