### PR TITLE
adds --parallel-options option to parallel_stereo

### DIFF
--- a/docs/tools/parallel_stereo.rst
+++ b/docs/tools/parallel_stereo.rst
@@ -100,4 +100,6 @@ These can be customized as shown in the options below.
     Do not launch the jobs, only print the commands that should be
     run.
 
+--parallel-options    
+    Passthrough for GNU parallel options, not validate.
    

--- a/docs/tools/parallel_stereo.rst
+++ b/docs/tools/parallel_stereo.rst
@@ -74,8 +74,8 @@ These can be customized as shown in the options below.
 --corr-seed-mode <integer (from 0 to 3)>  Correlation seed strategy
                                           (:numref:`corr_section`).
 
---sparse-disp-options <string>
-    Options to pass directly to sparse_disp (:numref:`sparse-disp`).
+--sparse-disp-options <string (default: "")>
+    Options to pass directly to sparse_disp (:numref:`sparse-disp`). Use quotes around this string.
 
 --verbose
     Display the commands being executed.
@@ -100,6 +100,6 @@ These can be customized as shown in the options below.
     Do not launch the jobs, only print the commands that should be
     run.
 
---parallel-options    
-    Passthrough for GNU parallel options, not validate.
+--parallel-options <string (default: "")>
+    Options to pass directly to GNU Parallel. For example, "--sshdelay 10 --controlmaster".
    

--- a/src/asp/Tools/parallel_stereo
+++ b/src/asp/Tools/parallel_stereo
@@ -468,7 +468,8 @@ def spawn_to_nodes(step, settings, args):
         cmd += ['--sshloginfile', opt.nodes_list]
     if opt.ssh is not None:
         cmd += ['--ssh', opt.ssh]
-
+    if opt.parallel_options is not None:
+        cmd += opt.parallel_options.split(' ')
     # Add the options which we want GNU parallel to not mess up
     # with. Put them into a single string. Before that, put in quotes
     # any quantities having spaces, to avoid issues later.
@@ -633,7 +634,8 @@ if __name__ == '__main__':
                    help='Explicitly specify the stereo.default file to use. [default: ./stereo.default]')
     p.add_argument('--verbose', dest='verbose', default=False, action='store_true',
                    help='Display the commands being executed.')
-
+    p.add_argument('--parallel-options', dest='parallel_options', default=None,
+                   help='Passthrough for GNU parallel options, not validated. [default: None]')
     # Internal variables below.
     # The id of the tile to process, 0 <= tile_id < num_tiles.
     p.add_argument('--tile-id', dest='tile_id', default=None, type=int,


### PR DESCRIPTION
adds gnu parallel options pass-through for parallel_stereo

## Description
adds a argparse param to parallel_stereo that accepts a string input of additional parameters for gnu parallel, currently not parsed/validated in any way as we assume gnu_parallel will handle the errors.

## Related Issue
fixes #335 

## Motivation and Context
allows passing in flags such as sshdelay to gnuparallel to work within bounds of hpc clusters

## How Has This Been Tested?
not tested 
## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to the StereoPipeline! -->
