### PR TITLE
Fix corner case crash with parse_match_file.py

### DIFF
--- a/src/asp/Tools/parse_match_file.py
+++ b/src/asp/Tools/parse_match_file.py
@@ -188,7 +188,9 @@ if __name__ == '__main__':
         # the specified fields.
         try:
             im1_ipb = np.genfromtxt(args.infile,skip_header=1,dtype='float32, float32, int32, int32, float32, float32, float32, int8, uint32, uint32, uint64', max_rows=size1)
+            im1_ipb = im1_ipb.reshape((size1,))
             im2_ipb = np.genfromtxt(args.infile,skip_header=1+int(size1),dtype='float32, float32, int32, int32, float32, float32, float32, int8, uint32, uint32, uint64', max_rows=size2)
+            im2_ipb = im2_ipb.reshape((size2,))
         except Exception as e:
             print("Your numpy version (" + str(np.__version__) + ") may be too old. " +
                   "Got the error: " + str(e))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When there is exactly one IP record in the match file the script `parse_match_file.py` fails.

Explanation: `np.genfromtxt` returns a tuple instead of an array cf <https://stackoverflow.com/questions/24429822/genfromtxt-generates-tuples-so-does-recfromcsv>.

This is problematic: the scripts fails with `TypeError: len() of unsized object` when calling `len(im1_ip)` (same with `len(im2_ip)`.

This PR reshapes the result so that it is always an array => prevents failure.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/NeoGeographyToolkit/StereoPipeline/issues/349

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR prevents a crash occurring when calling `parse_match_file.py` on a match file with a single IP Record for both or one image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If any of the tests below were *not* run, please delete the line -->

`test.bin.txt`

```
1 2
42.0 43.0 42 43 52.0 53.0 54.0 3 62 63 2 44.0 44.0
42.0 43.0 42 43 52.0 53.0 54.0 3 62 63 2 44.0 44.0
42.0 43.0 42 43 52.0 53.0 54.0 3 62 63 2 44.0 44.0
```

### **Without** this PR

```
python parse_match_file.py -rev test.bin.txt test.bin.out
```

output:

```
Reading: test.bin.txt
Writing: test.bin.out
Traceback (most recent call last):
  File "/home/redacted/clones/StereoPipeline/src/asp/Tools/parse_match_file.py", line 199, in <module>
    write_match_file(args.outfile, im1_ipb, im2_ipb)
  File "/home/redacted/clones/StereoPipeline/src/asp/Tools/parse_match_file.py", line 121, in write_match_file
    size1 = len(im1_ip)
TypeError: len() of unsized object
```

### **With** this PR

```
python parse_match_file.py -rev test.bin.txt test.bin.out
```

output:

```
Reading: test.bin.txt
Writing: test.bin.out
```

## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to the StereoPipeline! -->
