### PR TITLE
Add a projected input option to point2dem

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -51,7 +51,9 @@ rig_calibrator (:numref:`rig_calibrator`):
 
 point2dem (:numref:`point2dem`): 
   * Added the option ``--propagate-errors`` to grid the stddev values
-    computed during stereo triangulation. 
+    computed during stereo triangulation.
+  * Added the option ``--input-is-projected`` to specify that the input
+    coordinates are already in the projected coordinate system.
 
 stereo_gui (:numref:`stereo_gui`): 
   * Can read, write, edit, and overlay on top of images polygons in

--- a/docs/tools/point2dem.rst
+++ b/docs/tools/point2dem.rst
@@ -397,6 +397,10 @@ Command-line options for point2dem
     files, if those files contain Easting and Northing fields. If
     not specified, ``--t_srs`` will be used.
 
+--input-is-projected
+    Treat the input coordinates as already in the projected coordinate
+    system, avoiding the need to convert to geodetic coordinates.
+
 --rounding-error <float (default: 1/2^{10}=0.0009765625)>
     How much to round the output DEM and errors, in meters (more
     rounding means less precision but potentially smaller size on

--- a/docs/tools/point2dem.rst
+++ b/docs/tools/point2dem.rst
@@ -399,7 +399,7 @@ Command-line options for point2dem
 
 --input-is-projected
     Treat the input coordinates as already in the projected coordinate
-    system, avoiding the need to convert to geodetic coordinates.
+    system, avoiding the need to convert the points from ECEF.
 
 --rounding-error <float (default: 1/2^{10}=0.0009765625)>
     How much to round the output DEM and errors, in meters (more


### PR DESCRIPTION
I am working with indoor point cloud scans and adding this feature allowed me to generate DEM files from them.  Not sure how broadly useful this is but I could add an example for it.