### PR TITLE
Remove process limit in parallel_bundle_adjust

### DIFF
--- a/src/asp/Tools/parallel_bundle_adjust
+++ b/src/asp/Tools/parallel_bundle_adjust
@@ -170,10 +170,6 @@ def spawn_to_nodes(step, num_instances, output_prefix, argsIn):
         procs   = opt.processes
         threads = opt.threads
 
-    # Need not have more processes than instances.
-    if procs > num_instances:
-        procs = num_instances
-
     asp_cmd_utils.wipe_option(args, '--processes', 1)
     asp_cmd_utils.wipe_option(args, '--threads', 1)
     args.extend(['--processes', str(procs)])


### PR DESCRIPTION
removes limit on procs that I suspect prevents multiple jobs from being run on each node when resources allow. 
Otherwise you have to allocate many nodes with few cores to scale.


## Description

The '--max-procs' option for gnu parallel limits the number of jobs that can be run simultaneously across all machines available, not per node: (`Run up to num jobs in parallel`). I believe if the intent was to specify the number of jobs to run per node (machine), then the `--jobs` or `-j` parameter should be used instead. The documentation specifically around `--max-procs` is [very thin and unspecific](https://www.gnu.org/software/parallel/man.html), but given other tutorials and example usages I've seen it is far more common to use the `--jobs` parameter instead.

The current behavior limits that number to the number of instances, so if 8 instances are available to parallel, only 8 jobs can run simultaneously, even if many cores are allocated. This contradicts the description of [`--processes <integer>`](https://stereopipeline.readthedocs.io/en/latest/tools/parallel_bundle_adjust.html) that states: 

```
The number of processes to use per node. The default is to use as many processes as cores.
```

Alternatively, one can allocate many nodes, and limit the core count per node, but on some clusters that may not be as easy to schedule as jobs that use a smaller number of entire nodes.

The current fix I have is just to trust the user and delete the check.
So far I haven't tested this yet but expect this to be the problem

Opting to using `runInGnuParallel()` here is likely the better next step but haven't explored that yet. 

If this fix is generally acceptable, then I'll go about updating documentation prior to merging of this pr.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Not yet, in progress

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

