### PR TITLE
Add skipped/used images list outputs to sfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ src/asp/asp_date_config.h
 docs/_build
 GitHubReleases.txt
 
+.vscode
+*.code-workspace

--- a/docs/tools/sfs.rst
+++ b/docs/tools/sfs.rst
@@ -96,6 +96,14 @@ outputs are:
    this is more of an input quantity rather than the result of computing
    the albedo. That one is mentioned above.
 
+ - ``run/run-skipped_images.txt`` - a list of images that were skipped by ``sfs`` 
+   and were not used to produce the final result. If no images were skipped,
+   this file will not exist.
+
+ - ``run/run-used_images.txt`` - a list of images that were used by ``sfs`` 
+   to produce the final result. If no images were skipped,
+   this file will not exist.
+
 In addition, SfS saves intermediate values of many of these quantities
 at each iteration, unless the flag ``--save-sparingly`` is used. SfS
 may also save the "haze" values if this is solved for (see the

--- a/src/asp/SfS/SfsUtils.cc
+++ b/src/asp/SfS/SfsUtils.cc
@@ -217,6 +217,14 @@ std::string modelCoeffsFileName(std::string const& prefix) {
   return prefix + "-model_coeffs.txt";
 }
   
+std::string skippedImagesFileName(std::string const& prefix) {
+  return prefix + "-skipped_images.txt";
+}
+
+std::string usedImagesFileName(std::string const& prefix) {
+  return prefix + "-used_images.txt";
+}
+
 // Save the exposures to a file
 void saveExposures(std::string const& out_prefix,
                    std::vector<std::string> const& input_images,
@@ -248,5 +256,27 @@ void saveHaze(std::string const& out_prefix,
   }
   hzf.close();
 }
+
+// Save the skipped images list, these images had no/bad exposure
+//  so no good data for the DEM in them
+void saveSkippedImages(std::string const& out_prefix,
+                       std::vector<std::string> const& input_images) {
+  std::string skipped_file = skippedImagesFileName(out_prefix);
+  vw_out() << "Writing: " << skipped_file << std::endl;
+  std::ofstream skippedfile(skipped_file.c_str());
+  for (const auto& image : input_images)
+    skippedfile << image << "\n";
+}
+
+// Save the used images list, these images had good exposure
+void saveUsedImages(std::string const& out_prefix,
+                    std::vector<std::string> const& input_images) {
+  std::string used_file = usedImagesFileName(out_prefix);
+  vw_out() << "Writing: " << used_file << std::endl;
+  std::ofstream usedfile(used_file.c_str());
+  for (const auto& image : input_images)
+    usedfile << image << "\n";
+}
+
 
 } // end namespace asp

--- a/src/asp/SfS/SfsUtils.h
+++ b/src/asp/SfS/SfsUtils.h
@@ -57,6 +57,8 @@ vw::Vector3 sunPositionFromCamera(vw::CamPtr camera);
 std::string exposureFileName(std::string const& prefix);
 std::string hazeFileName(std::string const& prefix);
 std::string modelCoeffsFileName(std::string const& prefix);
+std::string skippedImagesFileName(std::string const& prefix);
+std::string usedImagesFileName(std::string const& prefix);
 
 // Save the exposures to a file
 void saveExposures(std::string const& out_prefix,
@@ -67,6 +69,14 @@ void saveExposures(std::string const& out_prefix,
 void saveHaze(std::string const& out_prefix,
               std::vector<std::string> const& input_images,
               std::vector<std::vector<double>> const& haze);
+
+// Save the skipped images list to a file
+void saveSkippedImages(std::string const& out_prefix,
+                       std::vector<std::string> const& input_images);
+
+// Save the used images list to a file
+void saveUsedImages(std::string const& out_prefix,
+                    std::vector<std::string> const& input_images);
 
 } // end namespace asp
 


### PR DESCRIPTION
## Description
This PR is meant to fix #457, by updating sfs to write out two text lists, a used_images.txt and skipped_images.txt that contain the full paths to each image used or skipped by sfs. 
 
## Related Issue
#457 

## Motivation and Context
fixes #457, and makes it easier to know which images were actually used or not for a given sfs tile.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If any of the tests below were *not* run, please delete the line -->

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- My change requires a change to the documentation.
- I have updated the documentation accordingly.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to the StereoPipeline! -->
