### PR TITLE
Replace broken CTX download links

### DIFF
--- a/docs/examples/ctx.rst
+++ b/docs/examples/ctx.rst
@@ -39,8 +39,8 @@ P03_002258_1817_XI_01N356W.IMG from PDS, at:
 
 The download commands are::
 
-    wget https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/ctx/mrox_0031/data/P02_001981_1823_XI_02N356W.IMG
-    wget https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/ctx/mrox_0042/data/P03_002258_1817_XI_01N356W.IMG
+    wget https://planetarydata.jpl.nasa.gov/img/data/mro/ctx/mrox_0031/data/P02_001981_1823_XI_02N356W.IMG
+    wget https://planetarydata.jpl.nasa.gov/img/data/mro/ctx/mrox_0042/data/P03_002258_1817_XI_01N356W.IMG
 
 Creation of cub files
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

The existing links in the CTX Section 8.3 example section are 404'ing. These links are correct and download the data.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✔️  My change requires a change to the documentation.
- ✔️ I have updated the documentation accordingly.
- ❌ I have added tests to cover my changes.
- ❌ All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.
