### PR TITLE
Updated ASTER example notebook link

### DIFF
--- a/docs/examples/aster.rst
+++ b/docs/examples/aster.rst
@@ -11,7 +11,7 @@ orbit is sun-synchronous, at an elevation of 705 km. The ground sample distance 
 meters/pixel. 
 
 See a `ready-made ASTER example <https://github.com/NeoGeographyToolkit/StereoPipelineSolvedExamples/releases/tag/ASTER>`_. It has the input images and
-cameras, ASP outputs, and instructions for how to run it. Also see a `workbook with illustrations <https://github.com/uw-cryo/asp-binder-demo/blob/master/example-aster_on_pangeo_binder_draft.ipynb>`_.
+cameras, ASP outputs, and instructions for how to run it. Also see a `workbook with illustrations <https://nbviewer.org/github/uw-cryo/asp_plot/blob/main/notebooks/ASTER/aster_with_mapprojection.ipynb>`_.
     
 ASP can correct for the jitter in these cameras (:numref:`jitter_aster`).
 


### PR DESCRIPTION
## Description

Fixes a broken link external link in the ASTER example using an updated notebook:

This old link was 404'ing: 

https://github.com/uw-cryo/asp-binder-demo/blob/master/example-aster_on_pangeo_binder_draft.ipynb

This is the updated notebook, prepared on https://github.com/uw-cryo/asp_plot/pull/92: 

https://nbviewer.org/github/uw-cryo/asp_plot/blob/main/notebooks/ASTER/aster_with_mapprojection.ipynb

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✔️  My change requires a change to the documentation.
- ✔️ I have updated the documentation accordingly.
- ❌ I have added tests to cover my changes.
- ❌ All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.
