### PR TITLE
Add asp_plot section to visualization documentation

### DIFF
--- a/docs/next_steps.rst
+++ b/docs/next_steps.rst
@@ -1252,6 +1252,35 @@ Produced DEMs can also be mosaicked (:numref:`dem_mosaic`), subtracted from
 other DEMs or CSV files (:numref:`geodiff`), aligned to a reference
 (:numref:`pc-align-example`), etc.
 
+.. _asp_plot:
+
+Diagnostic plots and reports with asp_plot
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `asp_plot <https://github.com/uw-cryo/asp_plot>`_ Python package can be
+used to generate diagnostic plots and comprehensive PDF reports from ASP
+outputs. It provides visualization of stereo DEMs (hillshades, colormaps,
+difference maps), bundle adjustment residuals, interest point matches,
+map-projected image overlays, CSM camera model comparisons, and stereo
+geometry. For Earth-based datasets, it also supports comparison against ICESat-2
+altimetry data via `SlideRule <https://slideruleearth.io/>`_.
+
+The ``asp_plot`` package supports processing outputs from many sensors,
+including WorldView, ASTER, LRO NAC, CTX, HiRISE, and MOC.
+
+``asp_plot`` is available via ``conda`` and ``pip``::
+
+    conda install -c conda-forge asp_plot
+
+or::
+
+    pip install asp_plot
+
+For full documentation, including installation, CLI usage, example notebooks,
+and example reports, see:
+
+    https://asp-plot.readthedocs.io
+
 .. _p19-osg:
 
 .. figure:: images/p19-osg_400px.png


### PR DESCRIPTION
## Summary

- Adds a new section about the [asp_plot](https://github.com/uw-cryo/asp_plot) Python package to the "Visualizing and manipulating the results" section of `next_steps.rst`
- Includes a brief description of asp_plot capabilities (diagnostic plots, PDF reports, multi-sensor support)
- Provides conda/pip install instructions
- Links to the dedicated documentation at https://asp-plot.readthedocs.io

## Context

The `asp_plot` package generates diagnostic plots and comprehensive PDF reports from ASP stereo processing outputs. It is independently maintained, conda/pip installable, and has its own documentation. Rather than bundling `asp_plot` with ASP (which would add many dependencies), this PR adds a short, prominent section in the ASP docs that directs users to the dedicated `asp_plot` documentation for full details, install instructions, example notebooks, and example reports.

## Notes

I'm not sure the current location in the "Visualizing and manipulating the results" section of `next_steps.rst` is the best place for this note, but it does somewhat logically fit. I'm open to other locations.