### PR TITLE
Improve point2dem default grid size

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,6 +45,7 @@ at the NASA Ames Research Center in Moffett Field, CA.
 - Joachim Meyer (University of Washington)
 - Jay Laura (USGS)
 - Shashank Bhushan (University of Washington)
+- `lavaFreak <https://github.com/lavaFreak>`_
 
 Acknowledgments
 ---------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -100,6 +100,11 @@ parallel_stereo (:numref:`parallel_stereo`):
   * The DEM for mapprojected images can be set with ``--dem`` instead of as the
     last positional argument (:numref:`mapproj-example`).
 
+point2dem (:numref:`point2dem`):
+  * When auto-estimating DEM resolution, use the average projected spacing from
+    the middle 25%-75% of samples and multiply the result by 4. This produces
+    a more robust default grid size for anisotropic line-scan cameras.
+
 sfs (:numref:`sfs`):
   * Recommend the variance-based uncertainty estimation (:numref:`sfs_unc`).
   * Added the option ``--save-covariances`` (:numref:`sfs_opt`).

--- a/docs/tools/point2dem.rst
+++ b/docs/tools/point2dem.rst
@@ -15,7 +15,8 @@ of the heights of points in the cloud (see ``--search-radius-factor``).
 The grid size is set with ``--tr`` for the given projection. The grid points are
 placed at integer multiples of the grid size, and the created DEM has a ground
 footprint that is outwardly larger by half a grid pixel than the bounding box of
-the grid points. If not set, the grid size is estimated automatically.
+the grid points. If not set, the grid size is estimated automatically as about
+four times the ground sample distance.
 The behavior is somewhat different with ``--gdal-tap``.
 
 A custom extent can be specified with the option ``--t_projwin``. This will be
@@ -428,8 +429,9 @@ Command-line options for point2dem
     Set output DEM resolution (in target georeferenced units per
     pixel). These units may be in meters or degrees, depending on the
     projection. If not specified, it will be computed automatically
-    (except for LAS and CSV files). Multiple spacings can be set
-    (in quotes) to generate multiple output files.
+    as about four times the estimated ground sample distance (except
+    for LAS and CSV files). Multiple spacings can be set (in quotes)
+    to generate multiple output files.
 
 -o, --output-prefix <string (default: "")>
     Specify the output prefix. The output DEM will be 
@@ -545,6 +547,12 @@ Command-line options for point2dem
     cloud point's contribution to a given DEM grid point, with *x* the
     distance in meters between the two. The default is -log(0.25) = 1.3863. A
     smaller value will result in a smoother terrain.
+
+--default-grid-size-multiplier <float (default: 4)>
+    If the output DEM grid size is not specified with ``--dem-spacing``,
+    estimate it automatically from the point cloud ground sample distance, then
+    multiply by this number. The default of 4 follows the usual rule of thumb
+    for DEM generation from image-derived point clouds.
 
 --csv-format <string (default: "")>
     Specify the format of input CSV files as a list of entries

--- a/src/asp/Core/OrthoRasterizer.cc
+++ b/src/asp/Core/OrthoRasterizer.cc
@@ -47,6 +47,29 @@ namespace asp{
 
   using namespace vw;
 
+  namespace {
+
+  double interquartile_mean(std::vector<double> & vals) {
+    if (vals.empty())
+      return 0.0;
+
+    std::sort(vals.begin(), vals.end());
+
+    size_t len = vals.size();
+    size_t begin = static_cast<size_t>(std::floor(0.25 * len));
+    size_t end = static_cast<size_t>(std::ceil(0.75 * len));
+    begin = std::min(begin, len - 1);
+    end = std::max(begin + 1, std::min(end, len));
+
+    double sum = 0.0;
+    for (size_t i = begin; i < end; i++)
+      sum += vals[i];
+
+    return sum / static_cast<double>(end - begin);
+  }
+
+  } // namespace
+
   class compare_bboxes { // simple comparison function
   public:
     bool operator()(const BBox2i A, const BBox2i B) const {
@@ -548,9 +571,8 @@ namespace asp{
                << " meters.\n";
     }
 
-    // Find the width and height of the median point cloud pixel in
-    // projected coordinates. For las or csv files, this approach
-    // does not work.
+    // Find representative point cloud pixel spacings in projected
+    // coordinates. For las or csv files, this approach does not work.
     int len = m_point_image_boundaries.size();
     if (!has_las_or_csv) {
       // This vectors can be large, so don't keep them for too long
@@ -563,20 +585,14 @@ namespace asp{
         vx.push_back(boundary.first.width() /sub_block_size);
         vy.push_back(boundary.first.height()/sub_block_size);
       }
-      std::sort(vx.begin(), vx.end());
-      std::sort(vy.begin(), vy.end());
-
-      if (len > 0) {
-        // Get the median
-        // TODO(oalexan1): This is not robust. For lro nac, vertical resolution
-        // and horizontal resolution differ by a factor of 4, e.g.,
-        // 0.5 m and 2 m. The median can be one of the two, which is
-        // wrong.  This code should be an average of the values in the
-        // [25%, 75%] range.
+      if (!vx.empty() && !vy.empty()) {
+        // Use the middle half of the sampled spacings. This avoids
+        // outliers while producing a better default for anisotropic
+        // line-scan cameras than a raw median.
         // TODO(oalexan1): Integrate with the logic for mapproject.
         // https://github.com/NeoGeographyToolkit/StereoPipeline/issues/173
-        m_default_spacing_x = vx[(int)(0.5*len)];
-        m_default_spacing_y = vy[(int)(0.5*len)];
+        m_default_spacing_x = interquartile_mean(vx);
+        m_default_spacing_y = interquartile_mean(vy);
       }
     }
 

--- a/src/asp/Core/PointToDem.cc
+++ b/src/asp/Core/PointToDem.cc
@@ -41,7 +41,7 @@ DemOptions::DemOptions():
   remove_outliers_with_pct(true), use_tukey_outlier_removal(false),
   max_valid_triangulation_error(0),
   erode_len(0), search_radius_factor(0), sigma_factor(0),
-  default_grid_size_multiplier(1.0),
+  default_grid_size_multiplier(4.0),
   has_las_or_csv_or_pcd(false), max_output_size(9999999, 9999999),
   auto_proj_center(false), input_is_projected(false) {}
 

--- a/src/asp/Tools/point2dem.cc
+++ b/src/asp/Tools/point2dem.cc
@@ -198,8 +198,8 @@ void handle_arguments(int argc, char *argv[], DemOptions& opt) {
      "weight to give to a cloud point contribution to a given DEM grid point, "
      "with x the distance in meters between the two. The default is -log(0.25) = 1.3863. "
      "A smaller value will result in a smoother terrain.")
-    ("default-grid-size-multiplier", po::value(&opt.default_grid_size_multiplier)->default_value(1.0),
-     "If the output DEM grid size (--dem-spacing) is not specified, compute it automatically (as the mean ground sample distance), and then multiply it by this number. It is suggested that this number be set to 4 though the default is 1.")
+    ("default-grid-size-multiplier", po::value(&opt.default_grid_size_multiplier)->default_value(4.0),
+     "If the output DEM grid size (--dem-spacing) is not specified, estimate it automatically from the ground sample distance and then multiply it by this number. The default is 4.")
     ("propagate-errors", po::bool_switch(&opt.propagate_errors)->default_value(false),  
      "Write files with names {output-prefix}-HorizontalStdDev.tif and {output-prefix}-VerticalStdDev.tif having the gridded stddev produced from bands 5 and 6 of the input point cloud, if this cloud was created with the option --propagate-errors. The same gridding algorithm is used as for creating the DEM.")
     ("no-dem", po::bool_switch(&opt.no_dem)->default_value(false),


### PR DESCRIPTION
## Description

Adjust `point2dem`'s default DEM spacing heuristic to match the existing TODO and issue discussion.

This change:
- switches the default `--default-grid-size-multiplier` from `1` to `4`
- replaces the raw median spacing estimate in `OrthoRasterizer` with an average over the middle 25%-75% of sampled projected spacings
- updates `point2dem` documentation and `NEWS.rst` to describe the new default behavior
- adds my GitHub handle to `AUTHORS.rst` per the contribution template

## Related Issue

Closes #173.

## Motivation and Context

The current default point2dem grid size underestimates DEM resolution and can produce poor defaults for anisotropic line-scan cameras where along-scan and cross-scan projected spacings differ substantially. The issue thread confirmed this narrow fix is still desired, and that the later polar-projection / outlier-removal ideas should stay out of scope.

## How Has This Been Tested?

- Reviewed the affected `point2dem` and `OrthoRasterizer` code paths against the issue requirements.
- Installed local build tooling (`cmake`, `ninja`) and ran a configure smoke test:
  - `cmake -S /Users/garion/Work/StereoPipeline -B /tmp/stereopipeline-build-check -G Ninja`
- The configure step reached the expected external dependency gate and stopped with `You need to set ASP_DEPS_DIR`, so I could not complete a full local build on this machine.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have not added automated tests locally; the maintainer noted in the issue that the change will affect nightly regressions and that they will handle that review/cleanup.
- I have not run the full existing test suite because the local ASP dependency environment is not available on this machine.

## Licensing:

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.
