### PR TITLE
Add geodiff reverse sign option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,6 +45,7 @@ at the NASA Ames Research Center in Moffett Field, CA.
 - Joachim Meyer (University of Washington)
 - Jay Laura (USGS)
 - Shashank Bhushan (University of Washington)
+- Garion Milazzo
 
 Acknowledgments
 ---------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -75,6 +75,10 @@ ipmatch (:numref:`ipmatch`):
     (:numref:`ipmatch_convert`).
   * Added an option for merging match files (:numref:`ipmatch_merge`).
 
+geodiff (:numref:`geodiff`):
+  * Added the option ``--reverse`` to flip the sign of the difference while
+    keeping the output on the first DEM's grid.
+
 image_calc (:numref:`image_calc`):
   * Added the option ``--stretch`` to stretch an image and save it with 8-bit
     pixels, for visualization purposes (:numref:`image_calc_stretch`).

--- a/docs/tools/geodiff.rst
+++ b/docs/tools/geodiff.rst
@@ -6,7 +6,8 @@ geodiff
 The ``geodiff`` program takes as input two DEMs, or a DEM and a CSV file, and
 subtracts the second from the first. The grid is from the first DEM, so the
 second one is interpolated into it using bilinear interpolation. When one file
-is a CSV, the grid from the DEM is used, regardless of the order of inputs. 
+is a CSV, the grid from the DEM is used, regardless of the order of inputs. Use
+``--reverse`` to flip the sign of the output while keeping the same grid.
 
 It is important to note that ``geodiff`` is very sensitive to the order of
 the two DEMs, due to the fact that the grid comes from the first one.
@@ -29,6 +30,14 @@ This will create ``run-diff.tif``.
 The ``stereo_gui`` program (:numref:`colorize`) can colorize on-the-fly and
 display the difference image. The ``colormap`` program (:numref:`colormap`) can
 write a colorized image.
+
+Take the difference of two DEMs in the first DEM's grid, but with the sign
+reversed::
+
+    geodiff --reverse dem1.tif dem2.tif -o run
+
+This will create ``run-diff.tif`` with values equal to ``dem2 - dem1`` on the
+grid of ``dem1``.
 
 Take the difference of a DEM and a CSV file::
 
@@ -58,6 +67,10 @@ Command-line options
 
 --absolute
     Output the absolute difference as opposed to just the difference.
+
+--reverse
+    Reverse the sign of the difference while keeping the output on the same
+    grid.
 
 --csv-format <string>
     Specify the format of input CSV files as a list of entries

--- a/src/asp/Tools/geodiff.cc
+++ b/src/asp/Tools/geodiff.cc
@@ -37,7 +37,7 @@ struct Options: vw::GdalWriteOptions {
   std::string dem1_file, dem2_file, output_prefix, csv_format_str, csv_srs, csv_proj4_str;
   double nodata_value;
 
-  bool use_float, use_absolute;
+  bool use_float, use_absolute, reverse;
 };
 
 void handle_arguments(int argc, char *argv[], Options& opt) {
@@ -52,6 +52,8 @@ void handle_arguments(int argc, char *argv[], Options& opt) {
      "the default, and this option is obsolete.")
     ("absolute", po::bool_switch(&opt.use_absolute)->default_value(false),
      "Output the absolute difference as opposed to just the difference.")
+    ("reverse", po::bool_switch(&opt.reverse)->default_value(false),
+     "Reverse the sign of the difference while keeping the output on the same grid.")
     ("csv-format", po::value(&opt.csv_format_str)->default_value(""),
      asp::csv_opt_caption().c_str())
     ("csv-srs", po::value(&opt.csv_srs)->default_value(""), 
@@ -168,11 +170,13 @@ void dem2dem_diff(Options& opt) {
     = asp::warpCrop(dem2_disk_image_view, dem2_nodata, dem2_georef,
                     dem1_georef, dem1_crop_box, "bilinear");
   
-  ImageViewRef<double> difference;
+  ImageViewRef<PixelMask<double>> difference = dem1_crop - dem2_trans;
+  if (opt.reverse)
+    difference = -difference;
   if (opt.use_absolute)
-    difference = apply_mask(abs(dem1_crop - dem2_trans), opt.nodata_value);
-  else
-    difference = apply_mask(dem1_crop - dem2_trans, opt.nodata_value);
+    difference = abs(difference);
+
+  ImageViewRef<double> masked_difference = apply_mask(difference, opt.nodata_value);
     
   GeoReference crop_georef = crop(dem1_georef, dem1_crop_box);
     
@@ -184,22 +188,22 @@ void dem2dem_diff(Options& opt) {
   auto tpc = TerminalProgressCallback("asp", "\t--> Differencing: ");
     
   if (opt.use_float) {
-    ImageViewRef<float> difference_float = channel_cast<float>(difference);
+    ImageViewRef<float> difference_float = channel_cast<float>(masked_difference);
     vw::cartography::block_write_gdal_image(output_file, difference_float,
                                             has_georef, crop_georef,
                                             has_nodata, opt.nodata_value,
                                             opt, tpc);
   } else {
-    vw::cartography::block_write_gdal_image(output_file, difference,
+    vw::cartography::block_write_gdal_image(output_file, masked_difference,
                                             has_georef, crop_georef,
                                             has_nodata, opt.nodata_value,
                                             opt, tpc);
   }
 }
 
-// From a DEM, subtract a csv file. Reverse the sign is 'reverse' is true.
+// From a DEM, subtract a csv file. Reverse the sign if 'reverse_csv' is true.
 void dem2csv_diff(Options & opt, std::string const& dem_file,
-                  std::string const & csv_file, bool reverse){
+                  std::string const & csv_file, bool reverse_csv){
   
   if (opt.csv_format_str == "")
     vw_throw(ArgumentErr() << "CSV files were passed in, but the "
@@ -289,7 +293,9 @@ void dem2csv_diff(Options & opt, std::string const& dem_file,
       continue;
 
     double diff = dem_ht.child() - llh[2];
-    if (reverse) 
+    if (reverse_csv)
+      diff *= -1;
+    if (opt.reverse)
       diff *= -1;
     if (opt.use_absolute)
       diff = std::abs(diff);
@@ -364,13 +370,13 @@ int main(int argc, char *argv[]) {
                << "Cannot do the diff of two csv files. One of them "
                << "can be converted to a DEM using point2dem fist.\n");
     
-    bool reverse = false; // true if first DEM is a csv
+    bool reverse_csv = false; // true if first DEM is a csv
     if (is_dem1_csv) {
-      reverse = true;
-      dem2csv_diff(opt, opt.dem2_file, opt.dem1_file, reverse);
+      reverse_csv = true;
+      dem2csv_diff(opt, opt.dem2_file, opt.dem1_file, reverse_csv);
     }else if (is_dem2_csv){
-      reverse = false;
-      dem2csv_diff(opt, opt.dem1_file, opt.dem2_file, reverse);
+      reverse_csv = false;
+      dem2csv_diff(opt, opt.dem1_file, opt.dem2_file, reverse_csv);
     }else{
       // Both are regular DEMs
       dem2dem_diff(opt);


### PR DESCRIPTION
## Description
This adds a small `geodiff` option, `--reverse`, that flips the sign of the output for DEM-vs-DEM and DEM-vs-CSV differences while keeping the existing sampling/output grid behavior unchanged.

The default behavior remains the same. When `--reverse` is passed for DEM inputs, `geodiff dem1.tif dem2.tif` still samples on the first DEM's grid, but the output becomes `dem2 - dem1` instead of `dem1 - dem2`. For DEM-vs-CSV differences, the new flag applies on top of the existing CSV reversal support.

This PR also updates the `geodiff` documentation and adds a short `NEWS` entry.

## Related Issue
Closes #242

## Motivation and Context
Issue #242 asked for a way to decouple the sign of the DEM difference from the output sampling grid. The smallest change that addresses that request is a sign-flip option that preserves the current output-grid behavior, instead of introducing a second-grid sampling mode.

## How Has This Been Tested?
- Reviewed the final patch with `git diff --check`.
- Ran a CMake configure smoke test with `cmake -S <repo-root> -B /tmp/stereopipeline-242-build -G Ninja`.
- The configure step progressed through compiler detection and then stopped at the existing local dependency gate because `ASP_DEPS_DIR` is not configured in my environment.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- My change requires a change to the documentation.
- I have updated the documentation accordingly.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.
