### PR TITLE
Preserve equals signs in --mo metadata values

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -386,6 +386,7 @@ image_subset (:numref:`image_subset`):
 
 misc:
   * Added minimum system requirements for running ASP (:numref:`system_rec`).
+  * Bugfix for the ``--mo`` metadata parser in ``image_calc`` and ``mapproject`` so values can contain ``=`` characters.
   * Made the OpticalBar model 3x faster by switching from minimization in 3D
     to root-finding in 2D with the Newton-Raphson method.
   * Turned off experimental ``--subpixel-mode 6`` as it is failing to run

--- a/src/asp/Core/AspStringUtils.cc
+++ b/src/asp/Core/AspStringUtils.cc
@@ -82,19 +82,18 @@ void parseKeysVals(std::string const& file,
 
 /// Parse 'VAR1=VAL1 VAR2=VAL2' into a map. Note that we append to the map,
 /// so it may have some items there beforehand.
-// TODO(oalexan1): This will fail if VAL1 has equal signs.
 void parse_append_metadata(std::string const& metadata,
                            std::map<std::string, std::string> & keywords) {
-  
+
   std::istringstream is(metadata);
-  std::string meta, var, val;
-  while (is >> meta){
-    
-    // TODO(oalexan1): Replace only first equal, to allow for equal signs in values.
-    boost::replace_all(meta, "=", " ");  // replace equal with space
-    std::istringstream is2(meta);
-    if (!(is2 >> var >> val)) 
+  std::string meta;
+  while (is >> meta) {
+    size_t equal_pos = meta.find('=');
+    if (equal_pos == std::string::npos || equal_pos == 0 || equal_pos + 1 >= meta.size())
       vw::vw_throw(vw::ArgumentErr() << "Could not parse: " << meta << "\n");
+
+    std::string var = meta.substr(0, equal_pos);
+    std::string val = meta.substr(equal_pos + 1);
     keywords[var] = val;
   }
 }

--- a/src/asp/Core/tests/TestAspStringUtils.cxx
+++ b/src/asp/Core/tests/TestAspStringUtils.cxx
@@ -1,0 +1,38 @@
+// __BEGIN_LICENSE__
+//  Copyright (c) 2009-2013, United States Government as represented by the
+//  Administrator of the National Aeronautics and Space Administration. All
+//  rights reserved.
+//
+//  The NGT platform is licensed under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance with the
+//  License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//  License for the specific language governing permissions and limitations
+//  under the License.
+// __END_LICENSE__
+
+#include <test/Helpers.h>
+#include <asp/Core/AspStringUtils.h>
+
+using namespace asp;
+
+TEST(AspStringUtils, ParseAppendMetadataPreservesEqualsInValues) {
+  std::map<std::string, std::string> keywords;
+  keywords["EXISTING"] = "keep";
+
+  parse_append_metadata("A=1 B=a=b C=x==y", keywords);
+
+  EXPECT_EQ("keep", keywords["EXISTING"]);
+  EXPECT_EQ("1", keywords["A"]);
+  EXPECT_EQ("a=b", keywords["B"]);
+  EXPECT_EQ("x==y", keywords["C"]);
+}
+
+TEST(AspStringUtils, ParseAppendMetadataRejectsMissingValue) {
+  std::map<std::string, std::string> keywords;
+  EXPECT_THROW(parse_append_metadata("A=", keywords), vw::ArgumentErr);
+}


### PR DESCRIPTION
## Description
This fixes metadata parsing for the `--mo` option so values may contain `=` characters.

Previously, `parse_append_metadata()` replaced all `=` characters in each `VAR=VALUE` token, which mangled values such as `A=a=b`. This change now splits only on the first `=` and preserves the rest of the value.

The PR also adds a small regression test for this parser behavior and a minor `NEWS.rst` entry.

## Related Issue
Closes #483

## Motivation and Context
Issue #483 describes a user-facing metadata parsing bug in the shared `--mo` path used by tools such as `image_calc` and `mapproject`. This is a small fix that preserves current behavior for normal inputs while allowing `=` to appear inside metadata values.

## How Has This Been Tested?
- Added a regression test for `parse_append_metadata()` covering values with embedded `=` characters.
- Added a regression test that rejects a missing value such as `A=`.
- Reviewed the final patch with `git diff --check`.
- Ran a CMake configure smoke test with `cmake -S <repo-root> -B /tmp/stereopipeline-483-build -G Ninja`.
- The configure step progressed through compiler detection and then stopped at the existing local dependency gate because `ASP_DEPS_DIR` is not configured in my environment.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the pvl project uses.
