### PR TITLE
Require explicit georef for point2dem CSV inputs

### DIFF
--- a/src/asp/Tools/point2dem.cc
+++ b/src/asp/Tools/point2dem.cc
@@ -420,6 +420,43 @@ void handle_arguments(int argc, char *argv[], DemOptions& opt) {
 
 } // end function handle_arguments()
 
+namespace {
+
+bool csv_input_requires_explicit_georef(asp::DemOptions const& opt,
+                                        asp::CsvConv const& csv_conv,
+                                        bool have_user_datum) {
+  if (opt.csv_srs != "" || have_user_datum)
+    return false;
+
+  if (!csv_conv.is_configured())
+    return false;
+
+  bool has_csv_input = false;
+  for (auto const& file: opt.pointcloud_files) {
+    if (asp::is_csv(file)) {
+      has_csv_input = true;
+      break;
+    }
+  }
+  if (!has_csv_input)
+    return false;
+
+  switch (csv_conv.get_format()) {
+    case asp::CsvConv::HEIGHT_LAT_LON:
+    case asp::CsvConv::LAT_LON_RADIUS_M:
+    case asp::CsvConv::LAT_LON_RADIUS_KM:
+    case asp::CsvConv::EASTING_HEIGHT_NORTHING:
+      return true;
+    case asp::CsvConv::XYZ:
+    case asp::CsvConv::PIXEL_XYVAL:
+      return false;
+  }
+
+  return false;
+}
+
+} // end namespace
+
 // Wrapper for rasterize_cloud that goes through all spacing values
 void rasterize_cloud_multi_spacing(const ImageViewRef<Vector3>& proj_points,
                                    DemOptions& opt,
@@ -491,6 +528,14 @@ int main(int argc, char *argv[]) {
     // Configure a CSV converter object according to the input parameters
     asp::CsvConv csv_conv;
     csv_conv.parse_csv_format(opt.csv_format_str, opt.csv_srs); // Modifies csv_conv
+
+    if (csv_input_requires_explicit_georef(opt, csv_conv, have_user_datum)) {
+      vw_throw(ArgumentErr()
+               << "CSV point clouds with geographic or projected coordinates require "
+               << "an explicit datum or SRS. Set one of --csv-srs, --t_srs, --datum, "
+               << "--reference-spheroid, or both --semi-major-axis and --semi-minor-axis.\n");
+    }
+
     vw::cartography::GeoReference csv_georef;
     // TODO(oalexan1): The logic below is fragile. Check all locations
     // where parse_georef is called and see if a datum is always set before being used.


### PR DESCRIPTION
## Description
Add a point2dem-specific guard that refuses geographic or projected CSV input unless the user provides an explicit datum or SRS.

This keeps the change narrowly scoped to the behavior discussed in #485 instead of changing shared CSV parsing behavior for other tools.

## Related Issue
Closes #485

## Motivation and Context
A plain lon/lat/height CSV passed to `point2dem` with no `--csv-srs`, `--datum`, `--reference-spheroid`, `--semi-major-axis` / `--semi-minor-axis`, or `--t_srs` can silently default to Earth. This change turns that case into an explicit error and tells the user which options can be used to fix it.

## How Has This Been Tested?
- Built `point2dem` locally from source in the StereoPipeline build environment.
- Ran `point2dem` on a small `lon/lat/height_above_datum` CSV without any explicit datum or SRS settings and verified that it now fails with the new error.
- Ran `point2dem` on the same CSV with `--datum WGS84` and verified that it gets past the new guard and completes.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.
