### PR TITLE
[WIP, Do Not Merge] - `mapproject`: write a log file by default

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -32,6 +32,13 @@ parallel_stereo (:numref:`parallel_stereo`):
     ``--min-num-ip`` is kept for backward compatibility
     (:numref:`stereodefault`).
 
+mapproject (:numref:`mapproject`):
+  * A log file is now written by default next to the output image, named
+    ``<output image>-log-mapproject-<timestamp>-<pid>.txt``. It records the
+    command, the software version, system information, and the projection
+    information, similar to the logs of ``bundle_adjust`` and
+    ``parallel_stereo``. This can be turned off with ``--no-log``.
+
 cam_gen (:numref:`cam_gen`):
   * Added ``--csm-refit-distortion`` to refit the lens distortion of a CSM
     Frame camera to a chosen type while keeping the pose and other intrinsics

--- a/docs/tools/mapproject.rst
+++ b/docs/tools/mapproject.rst
@@ -469,6 +469,15 @@ Command-line options
     the rotation and translation from the .adjust file, the DEM it
     mapprojected onto, and the value of the ``--mo`` option.
 
+--no-log
+    Do not write a log file. By default, a file named
+    ``<output image>-log-mapproject-<timestamp>-<pid>.txt`` is written next
+    to the output image, recording the command that was run, the software
+    version, system information, and the projection information (grid size
+    and projected bounding box), similar to the log files produced by
+    ``bundle_adjust`` and ``parallel_stereo``. Such a log is not written
+    when only ``--query-projection`` or ``--query-pixel`` is invoked.
+
 --nodata-value <float (default: -32768)>
     No-data value to use unless specified in the input image.
 

--- a/src/asp/Tools/mapproject
+++ b/src/asp/Tools/mapproject
@@ -222,6 +222,86 @@ def maybe_copy_rpc(inputPath, outputPath):
             print("Copied " + input_rpc + " to " + output_rpc)
             shutil.copy(input_rpc, output_rpc)
 
+class Tee(object):
+    """A file-like object that writes to a console stream and a log handle."""
+    def __init__(self, stream, logHandle):
+        self.stream    = stream
+        self.logHandle = logHandle
+    def write(self, data):
+        self.stream.write(data)
+        try:
+            self.logHandle.write(data)
+        except Exception:
+            pass # Never let logging break the run
+    def flush(self):
+        self.stream.flush()
+        try:
+            self.logHandle.flush()
+        except Exception:
+            pass
+
+def getAspVersionHeader():
+    """
+    Return header lines mirroring the C++ asp::log_to_file output:
+    'ASP <version>', and, if available, 'Build ID: ...' and 'Build date: ...'.
+    """
+    out = ""
+    try:
+        p = subprocess.Popen(['mapproject_single', '--version'],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             universal_newlines=True)
+        out, err = p.communicate()
+    except OSError:
+        pass
+
+    version = ""; build_id = ""; build_date = ""
+    for line in out.split("\n"):
+        if not version:
+            m = re.search(r"(\d[\w.\-]*)", line) # first numeric token is the version
+            if m:
+                version = m.group(1)
+        if (not build_id) and ("Build ID:" in line):
+            build_id = line.split("Build ID:")[1].strip()
+        if (not build_date) and ("Build date:" in line):
+            build_date = line.split("Build date:")[1].strip()
+
+    lines = ["ASP " + version + "\n"]
+    if build_id != "":
+        lines.append("Build ID: " + build_id + "\n")
+    if build_date != "":
+        lines.append("Build date: " + build_date + "\n")
+    return lines
+
+def logSystemInfo(lg):
+    """Append basic system info to the open log handle, mirroring asp::log_to_file."""
+    def appendCmd(cmd):
+        try:
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 universal_newlines=True, shell=True)
+            out, err = p.communicate()
+            lg.write(out)
+        except Exception:
+            pass
+    appendCmd("uname -a")
+    if os.path.exists("/proc/meminfo"):
+        appendCmd("cat /proc/meminfo 2>/dev/null | grep MemTotal")
+    if os.path.exists("/proc/cpuinfo"):
+        appendCmd("cat /proc/cpuinfo 2>/dev/null | tail -n 25")
+    # The line below is for MacOSX
+    appendCmd("sysctl -a hw 2>/dev/null | grep -E "
+              "\"ncpu|byteorder|memsize|cpufamily|cachesize|mmx|sse|machine|model\" "
+              "| grep -v ipv6")
+    lg.write("\n")
+
+def formatCommand(progName, argsIn):
+    """Reconstruct the command line, quoting tokens that contain spaces."""
+    tokens = [progName]
+    for tok in argsIn:
+        if (" " in tok) or ("\t" in tok):
+            tok = '"' + tok + '"'
+        tokens.append(tok)
+    return " ".join(tokens)
+
 def main(argsIn):
 
     relOutputPath = ""
@@ -284,6 +364,13 @@ def main(argsIn):
     parser.add_argument("--no-geoheader-info", action="store_true", default=False,
       dest="noGeoHeaderInfo",
       help="Suppress writing some auxiliary information in geoheaders.")
+
+    parser.add_argument("--no-log", action="store_true", default=False,
+      dest="noLog",
+      help="Do not write a log file. By default, a file named "         + \
+      "<output image>-log-mapproject-<timestamp>-<pid>.txt is written "  + \
+      "next to the output image, recording the command, the software "   + \
+      "version, and the projection information.")
 
     # DEBUG options
     parser.add_argument("--keep", action="store_true", dest="keep", default=False,
@@ -422,6 +509,56 @@ def main(argsIn):
     fullWidth  = int(querySettings['image_width'][0])
     fullHeight = int(querySettings['image_height'][0])
     print('Output image size is ' + str(fullWidth) + ' by ' + str(fullHeight) + ' pixels.')
+
+    # Write a log file, similar to other ASP tools, so that the command, the
+    # software version, and the projection information are recorded for
+    # documentation and for tools such as asp_plot to parse. The spawned
+    # per-tile copies and the query-only modes return before reaching this
+    # point, so only the main process writes a log. Console output of this
+    # script (but not of the per-tile sub-processes) is teed into the log too.
+    logHandle = None
+    origStdout = sys.stdout
+    origStderr = sys.stderr
+    if not options.noLog:
+        outputName = os.path.basename(options.outputPath)
+        timestamp  = time.strftime("%m-%d-%H%M%S")
+        logName    = os.path.splitext(outputName)[0] + \
+                     "-log-mapproject-" + timestamp + "-" + str(os.getpid()) + ".txt"
+        logPath    = os.path.join(outputFolder, logName)
+        try:
+            logHandle = open(logPath, "w")
+        except Exception as e:
+            print("Warning: Could not open log file: " + logPath + ". " + str(e))
+            logHandle = None
+
+    if logHandle is not None:
+        print("Writing log: " + logPath)
+        # Version and build info
+        for line in getAspVersionHeader():
+            logHandle.write(line)
+        logHandle.write("\n")
+        # The command being run
+        logHandle.write(formatCommand('mapproject', argsIn) + "\n\n")
+        # System info
+        logSystemInfo(logHandle)
+        # Inputs. The 'Input DEM' line is recognized by asp_plot.
+        logHandle.write(time.strftime("%Y-%m-%d %H:%M:%S") + " -- Started mapproject\n")
+        logHandle.write("Input DEM: "    + options.demPath    + "\n")
+        logHandle.write("Input image: "  + options.imagePath  + "\n")
+        logHandle.write("Input camera: " + options.cameraPath + "\n")
+        logHandle.write("Output image: " + options.outputPath + "\n\n")
+        # Projection information from the query-projection pass
+        logHandle.write("Output image size is " + str(fullWidth) + " by " +
+                        str(fullHeight) + " pixels.\n")
+        for key in ['pixel_size', 'proj_box_xmin', 'proj_box_ymin',
+                    'proj_box_xmax', 'proj_box_ymax']:
+            if key in querySettings:
+                logHandle.write(key + "," + querySettings[key][0] + "\n")
+        logHandle.write("\n")
+        logHandle.flush()
+        # Tee further console output of this script into the log as well.
+        sys.stdout = Tee(origStdout, logHandle)
+        sys.stderr = Tee(origStderr, logHandle)
 
     # Propagate the projection box and ground resolution obtained by the
     # query-projection call. Drop any redundant or conflicting options.
@@ -628,6 +765,14 @@ def main(argsIn):
 
     endTime = time.time()
     print("Finished in " + str(endTime - startTime) + " seconds.")
+
+    # Close the log, restoring the original console streams first so no further
+    # writes reach a closed handle.
+    if logHandle is not None:
+        print(time.strftime("%Y-%m-%d %H:%M:%S") + " -- Finished mapproject")
+        sys.stdout = origStdout
+        sys.stderr = origStderr
+        logHandle.close()
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Description

mapproject now writes a log next to the output image, named <output image>-log-mapproject-<timestamp>-<pid>.txt, mirroring the logs produced by bundle_adjust and parallel_stereo. It records the command, the software version and build, system information, and the projection information (grid size and projected bounding box).

The log is written by the parallel wrapper (the main process), since the per-tile mapproject_single calls do not see the whole job. The spawned per-tile copies and the --query-projection / --query-pixel query-only modes return before the logging block, so they do not write a log. Console output of the wrapper is teed into the log as well.

This lets tools such as asp_plot parse the mapproject parameters and the projection window. Add a --no-log option to opt out. Document the option and add a NEWS entry.

## Related Issue

Related to https://github.com/uw-cryo/asp_plot/issues/96

## Motivation and Context

We would like a way to parse and record mapproject parameters for the `asp_plot` reporting.

## How Has This Been Tested?

Tested locally against an existing ASP install, by running the **edited** wrapper script in isolation (no rebuild, no changes to the install), on an un-projected ASTER TIF/XML pair.

### Isolation workflow (also a handy recipe for testing wrapper changes in general)

The `mapproject` script finds its Python helpers and binaries relative to its own path and prepends them to `PATH`. So the edited script can be run directly while pointing `PATH` at an existing install for the compiled tools — the install is never modified, and all outputs land in a throwaway directory:

```bash
# Edited wrapper from the source tree; compiled binaries from the install.
EDITED="$HOME/Desktop/uw-github/StereoPipeline/src/asp/Tools/mapproject"
export PATH="$HOME/asp/dev/bin:$PATH"        # NOTE: bin first (see below)

WORK=$(mktemp -d /tmp/mapproj-test.XXXXXX)
cp ~/Desktop/asp-plot-examples/aster/out-Band3N.{tif,xml} "$WORK/"
cd "$WORK"

# Project onto the WGS84 datum (no DEM file needed); --mpp 100 just for speed.
"$HOME/asp/dev/bin/python3" "$EDITED" -t aster WGS84 \
    out-Band3N.tif out-Band3N.xml out-Band3N_map.tif --mpp 100

cat "$WORK"/*log-mapproject*.txt             # inspect the new log
cd / && rm -rf "$WORK"                        # cleanup
```

What this exercises: the parent wrapper (edited) and its Python helpers come from the source tree, and the per-tile child processes resolve back to the edited `src/asp/Tools/mapproject` too; only the compiled `mapproject_single`, `gdalinfo`, GNU parallel, etc. come from the install via `PATH`.

> Gotcha: put the install's `bin` ahead of `libexec` in `PATH`. The `bin/*` entries are wrapper scripts that set up the environment; invoking the raw `libexec/mapproject_single` directly can hang on exit on a coverage-instrumented build (it sits in an uninterruptible `STAT UE` state writing `default.profraw`, which looks like a hang rather than a crash).

### Result

The run completed (exit 0) and wrote `out-Band3N_map.tif` plus the log `out-Band3N_map-log-mapproject-<timestamp>-<pid>.txt`:

```
ASP 3.7.0-alpha
Build ID: f04bc27
Build date: 2026-03-25

mapproject -t aster WGS84 out-Band3N.tif out-Band3N.xml out-Band3N_map.tif --mpp 100

Darwin Bens-MacBook-Air-2.local 25.3.0 ... RELEASE_ARM64_T8112 x86_64
hw.ncpu: 8
hw.memsize: 17179869184
... (system info trimmed) ...

2026-06-25 11:06:46 -- Started mapproject
Input DEM: WGS84
Input image: out-Band3N.tif
Input camera: out-Band3N.xml
Output image: out-Band3N_map.tif

Output image size is 768 by 729 pixels.
pixel_size,100
proj_box_xmin,549000
proj_box_ymin,5172300
proj_box_xmax,625700
proj_box_ymax,5245100

Splitting into 1 by 1 tiles.
... (per-tile rendering and gdal_translate console output teed in) ...
Wrote: out-Band3N_map.tif
Finished in 421.6 seconds.
2026-06-25 11:13:39 -- Finished mapproject
```

This is the shape `asp_plot` parses: the `ASP <version>` banner, the `mapproject ...` command line, the `Input DEM:` line, the projection window, and first/last timestamps (for duration).

### Negative cases (no log written, as intended)

- `--no-log` → no log file.
- `--query-projection` and `--query-pixel` query-only modes → no log file.
- Spawned per-tile copies → no log file.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Not sure about these two:

- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.
