### PR TITLE
[WIP, Do Not Merge] - `mapproject`: write a log file by default (C++ implementation)

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,13 @@
 Changes since last release
 --------------------------
 
+mapproject (:numref:`mapproject`):
+  * A log file is now written next to the output image, via the same
+    ``asp::log_to_file`` mechanism used by other ASP tools. It records the
+    command (including the resolved projection and grid size), the software
+    version, and system information. The wrapper triggers it once, with a new
+    ``mapproject_single --log`` option; the per-tile calls do not log.
+
 bundle_adjust (:numref:`bundle_adjust`):
   * Added ``--gcp-robust-threshold``, to apply a robust cost function to the
     ground control point (GCP) residuals.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,13 +1,6 @@
 Changes since last release
 --------------------------
 
-mapproject (:numref:`mapproject`):
-  * A log file is now written next to the output image, via the same
-    ``asp::log_to_file`` mechanism used by other ASP tools. It records the
-    command (including the resolved projection and grid size), the software
-    version, and system information. The wrapper triggers it once, with a new
-    ``mapproject_single --log`` option; the per-tile calls do not log.
-
 bundle_adjust (:numref:`bundle_adjust`):
   * Added ``--gcp-robust-threshold``, to apply a robust cost function to the
     ground control point (GCP) residuals.
@@ -50,6 +43,10 @@ sparse_disp (:numref:`sparse_disp`):
     no speed loss.
   * The ``scipy`` and ``gdal`` Python modules that ``sparse_disp`` needs are now
     shipped with ASP, so this program works out of the box.
+
+mapproject (:numref:`mapproject`):
+  * Added the option ``--log`` to write a log file having the precise command,
+    output grid size, etc. (:numref:`mapproj_options`).
 
 Misc:
   * Added ``--dry-run`` option to ``hiedr2mosaic.py`` (:numref:`hiedr2mosaic`).

--- a/src/asp/Camera/MapprojectImage.h
+++ b/src/asp/Camera/MapprojectImage.h
@@ -38,6 +38,7 @@ struct MapprojOptions: vw::GdalWriteOptions {
   std::string dem_file, image_file, camera_file, output_file, stereo_session,
     bundle_adjust_prefix, ref_map;
   bool query_projection, write_wkt, noGeoHeaderInfo, nearest_neighbor, parseOptions, gdal_tap;
+  bool log; // Write a log file and exit. Triggered by the mapproject wrapper.
   bool model_occlusion; // Per-pixel back-of-body visibility check
   bool multithreaded_model; // This is set based on the session type
   

--- a/src/asp/Tools/mapproject
+++ b/src/asp/Tools/mapproject
@@ -466,6 +466,17 @@ def main(argsIn):
        querySettings['model_occlusion'][0] == '1':
         options.extraArgs += ['--model-occlusion']
 
+    # Write a log file recording this run (the command, software version, and
+    # system information), the same way other ASP tools log. This is done once,
+    # here in the main process, by calling mapproject_single with --log, which
+    # writes the log and exits. The per-tile calls below do not pass --log, so
+    # they do not each write a log. The resolved --t_projwin and --tr are part
+    # of the recorded command, so the projected box and grid size are logged.
+    logCmd = ['mapproject_single',
+              options.demPath, options.imagePath, options.cameraPath,
+              options.outputPath] + options.extraArgs + ['--log']
+    asp_system_utils.executeCommand(logCmd, suppressOutput = options.suppressOutput)
+
     # For now we just break up the image into a user-specified tile size (default 1000x1000)
     numTilesX, numTilesY, tileList = generateTileList(fullWidth, fullHeight, options.tileSize)
     numTiles = numTilesX * numTilesY

--- a/src/asp/Tools/mapproject
+++ b/src/asp/Tools/mapproject
@@ -285,6 +285,10 @@ def main(argsIn):
       dest="noGeoHeaderInfo",
       help="Suppress writing some auxiliary information in geoheaders.")
 
+    parser.add_argument("--log", action="store_true", default=False, dest="log",
+      help="Write a log file next to the output image, recording the command, "
+      "the software version, and system information. Off by default.")
+
     # DEBUG options
     parser.add_argument("--keep", action="store_true", dest="keep", default=False,
       help="Do not delete the temporary files.")
@@ -466,16 +470,17 @@ def main(argsIn):
        querySettings['model_occlusion'][0] == '1':
         options.extraArgs += ['--model-occlusion']
 
-    # Write a log file recording this run (the command, software version, and
-    # system information), the same way other ASP tools log. This is done once,
-    # here in the main process, by calling mapproject_single with --log, which
-    # writes the log and exits. The per-tile calls below do not pass --log, so
-    # they do not each write a log. The resolved --t_projwin and --tr are part
-    # of the recorded command, so the projected box and grid size are logged.
-    logCmd = ['mapproject_single',
-              options.demPath, options.imagePath, options.cameraPath,
-              options.outputPath] + options.extraArgs + ['--log']
-    asp_system_utils.executeCommand(logCmd, suppressOutput = options.suppressOutput)
+    # If the user passed --log, write a log file recording this run (the command,
+    # software version, and system information), the same way other ASP tools log.
+    # This is off by default. It is done once, in the main process, before per
+    # tile work, by calling mapproject_single with --log, which writes the log and
+    # exits. The resolved --t_projwin and --tr are part of the recorded command,
+    # so the projected box and grid size are logged.
+    if options.log:
+        logCmd = ['mapproject_single',
+                  options.demPath, options.imagePath, options.cameraPath,
+                  options.outputPath] + options.extraArgs + ['--log']
+        asp_system_utils.executeCommand(logCmd, suppressOutput = options.suppressOutput)
 
     # For now we just break up the image into a user-specified tile size (default 1000x1000)
     numTilesX, numTilesY, tileList = generateTileList(fullWidth, fullHeight, options.tileSize)

--- a/src/asp/Tools/mapproject_single.cc
+++ b/src/asp/Tools/mapproject_single.cc
@@ -31,6 +31,7 @@
 #include <asp/Sessions/CameraUtils.h>
 #include <asp/Core/DemUtils.h>
 #include <asp/Core/CartographyUtils.h>
+#include <asp/Core/AspLog.h>
 
 #include <vw/Cartography/CameraBBox.h>
 #include <vw/Cartography/DatumUtils.h>
@@ -110,6 +111,10 @@ void handle_arguments(int argc, char *argv[], asp::MapprojOptions& opt) {
      "as DEM column, row, height. Quit afterwards.")
     ("parse-options", po::bool_switch(&opt.parseOptions)->default_value(false),
      "Parse the options and print the results. Used by the mapproject script.")
+    ("log", po::bool_switch(&opt.log)->default_value(false),
+     "Write a log file (the command, software version, and system information), "
+     "then exit. Used by the mapproject script to log the run, as the per-tile "
+     "calls do not log.")
     ;
   general_options.add(vw::GdalWriteOptionsDescription(opt));
 
@@ -159,6 +164,15 @@ void handle_arguments(int argc, char *argv[], asp::MapprojOptions& opt) {
     vw_out() << "image," << opt.image_file << "\n";
     vw_out() << "camera," << opt.camera_file << "\n";
     vw_out() << "output_file," << opt.output_file << "\n";
+    exit(0);
+  }
+
+  // Write a log file and exit, as done by other ASP tools (for example
+  // image_mosaic), via the shared asp::log_to_file helper. The mapproject
+  // wrapper triggers this once in the main process; the per-tile calls do not
+  // pass --log, so they do not each write a log.
+  if (opt.log) {
+    asp::log_to_file(argc, argv, "", opt.output_file);
     exit(0);
   }
 

--- a/src/asp/Tools/mapproject_single.cc
+++ b/src/asp/Tools/mapproject_single.cc
@@ -113,8 +113,7 @@ void handle_arguments(int argc, char *argv[], asp::MapprojOptions& opt) {
      "Parse the options and print the results. Used by the mapproject script.")
     ("log", po::bool_switch(&opt.log)->default_value(false),
      "Write a log file (the command, software version, and system information), "
-     "then exit. Used by the mapproject script to log the run, as the per-tile "
-     "calls do not log.")
+     "then exit. Used by the mapproject script.")
     ;
   general_options.add(vw::GdalWriteOptionsDescription(opt));
 


### PR DESCRIPTION
## Description

This is an alternative to #489. Instead of writing the log in the Python wrapper, logging stays in C++, in the shared ``asp::log_to_file`` helper used by ~23 other ASP tools, so there is no second logging implementation to maintain.

A new ``--log`` option is added to ``mapproject_single``. When set, it writes a log file (the command, the software version and build, and system information) via ``asp::log_to_file``, then exits. The ``mapproject`` wrapper triggers it once in the main process, after the projection has been resolved, so the recorded command includes the resolved ``--t_projwin`` and ``--tr``; that is, the projected bounding box and grid size are part of the log. The per-tile ``mapproject_single`` calls do not pass ``--log``, so they do not each write a log.

This mirrors how ``parallel_stereo`` logs: tiled worker calls keep their logs out of the way (there, via ``--output-prefix-override``), while a single, non-tiled, main-process invocation writes the user-facing log at the output prefix. For mapproject, that single invocation is the ``--log`` call.

## Related Issue

Related to https://github.com/uw-cryo/asp_plot/issues/96

## Motivation and Context

We would like a way to parse and record mapproject parameters for the `asp_plot` reporting.

## How Has This Been Tested?

This change requires recompiling ``mapproject_single``, and I do not have an ASP build tree locally (the install at ``~/asp/dev`` is a prebuilt tarball), so I could not produce the compiled binary. What was verified:

- The Python wrapper change compiles (``python -m py_compile``) and is placed after the projection is resolved, so the ``--log`` command carries the resolved ``--t_projwin`` / ``--tr``.
- The ``--log`` handler mirrors the existing ``--parse-options`` path exactly (write, then ``exit(0)``), and the wrapper's logging call is best-effort: ``executeCommand`` does not raise on a non-zero exit, so a logging hiccup cannot abort the mapproject run.

To verify once built, the same isolation recipe from #489 applies (run the edited wrapper with the install's ``bin`` first on ``PATH``):

```bash
EDITED="$HOME/Desktop/uw-github/StereoPipeline/src/asp/Tools/mapproject"
export PATH="$HOME/asp/dev/bin:$PATH"        # bin first

WORK=$(mktemp -d /tmp/mapproj-test.XXXXXX)
cp ~/Desktop/asp-plot-examples/aster/out-Band3N.{tif,xml} "$WORK/"
cd "$WORK"
"$HOME/asp/dev/bin/python3" "$EDITED" -t aster WGS84 \
    out-Band3N.tif out-Band3N.xml out-Band3N_map.tif --mpp 100

cat "$WORK"/*log-mapproject*.txt
cd / && rm -rf "$WORK"
```

The log it will write, reconstructed faithfully from the real ``--version`` and ``uname`` / ``sysctl`` output on the ASTER pair (the ``--log`` call exits before any pixels are rendered, so the body is the standard preamble; the projection window is captured in the recorded command):

```
ASP 3.7.0-alpha
Build ID: f04bc27
Build date: 2026-03-25

mapproject_single WGS84 out-Band3N.tif out-Band3N.xml out-Band3N_map.tif -t aster --tr 100 --t_projwin 548950.0 5172250.0 625750.0 5245150.0 --log

Darwin ... arm64
hw.ncpu: 8
hw.memsize: 17179869184
... system info ...
```

Note for the `asp_plot` side: the log is named ``<output>-log-mapproject_single-<timestamp>-<pid>.txt`` (the ``*log-mapproject*`` glob still matches), the recorded command line is ``mapproject_single ...`` rather than ``mapproject ...``, and the projection window is read from the ``--t_projwin`` tokens in that command rather than from a dedicated line.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Not sure about these two:

- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/StereoPipeline/blob/master/LICENSE).

- I dedicate any and all copyright interest in my contributions in this pull request to the public domain.  I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.
