### PR TITLE
skip-image-normalization: allow census cost modes and all supported image formats

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,6 +43,11 @@ image_align (:numref:`image_align`):
     per-match uncertainty (:numref:`correlation_uncertainty`).
 
 parallel_stereo (:numref:`parallel_stereo`):
+  * ``--skip-image-normalization`` now accepts any GDAL-supported input
+    image format, including ``.vrt``, allowing large mapprojected images
+    to be windowed or mosaicked virtually with no pixel copies. VRT
+    inputs are re-serialized rather than symlinked, which canonicalizes
+    their internal source paths (:numref:`stereodefault`).
   * ``--skip-image-normalization`` now also works with the census cost
     modes (``--cost-mode`` 3 and 4, as used by ``asp_sgm`` / ``asp_mgm``),
     which are invariant to a linear scaling of the inputs. Previously the

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,6 +43,11 @@ image_align (:numref:`image_align`):
     per-match uncertainty (:numref:`correlation_uncertainty`).
 
 parallel_stereo (:numref:`parallel_stereo`):
+  * ``--skip-image-normalization`` now also works with the census cost
+    modes (``--cost-mode`` 3 and 4, as used by ``asp_sgm`` / ``asp_mgm``),
+    which are invariant to a linear scaling of the inputs. Previously the
+    option required ``--cost-mode 2``, making it unusable with the SGM
+    family of algorithms (:numref:`stereodefault`).
   * Expanded the KH-9 panoramic camera example (:numref:`kh9`) in light of
     recent processing best practices (addition of anchor points, gcp robust
     threshold, camera position controls with CSM cameras).

--- a/docs/stereodefault.rst
+++ b/docs/stereodefault.rst
@@ -250,14 +250,18 @@ skip-image-normalization
     nodata-pixels. Create instead symbolic links to original images. This is a
     speedup option for mapprojected input images. It is supported only with no
     alignment (``alignment-method none``), no crop windows, no bathymetry,
-    ``.tif``/``.ntf`` inputs, and a scale-invariant cost function:
+    inputs in a GDAL-supported image format (such as ``.tif``, ``.ntf``, or
+    ``.vrt``), and a scale-invariant cost function:
     ``--cost-mode 2`` (normalized cross-correlation, ``asp_bm``) or
     ``--cost-mode 3``/``4`` (census / ternary census, ``asp_sgm`` /
     ``asp_mgm``). The SGM/MGM correlator converts each tile to uint8 with a
     per-tile min-max stretch, so skipping the global normalization does not
-    change the integer disparity. Note that with this option an orthoimage
-    produced by ``point2dem --orthoimage`` carries the raw input pixel values
-    rather than normalized values; the DEM geometry is unaffected.
+    change the integer disparity for valid-data tiles. Note that with this
+    option an orthoimage produced by ``point2dem --orthoimage`` carries the
+    raw input pixel values rather than normalized values; the DEM geometry is
+    unaffected. A ``.vrt`` input is copied (re-serialized by the GDAL VRT
+    driver) rather than symlinked, which canonicalizes the source paths
+    stored inside it for the new location and makes the run self-contained.
           
 nodata-value (default = NaN)
     Pixels with values less than or equal to this number are treated as

--- a/docs/stereodefault.rst
+++ b/docs/stereodefault.rst
@@ -248,7 +248,16 @@ matches-as-txt
 skip-image-normalization
     Skip the step of normalizing the values of input images and removing
     nodata-pixels. Create instead symbolic links to original images. This is a
-    speedup option for mapprojected input images.
+    speedup option for mapprojected input images. It is supported only with no
+    alignment (``alignment-method none``), no crop windows, no bathymetry,
+    ``.tif``/``.ntf`` inputs, and a scale-invariant cost function:
+    ``--cost-mode 2`` (normalized cross-correlation, ``asp_bm``) or
+    ``--cost-mode 3``/``4`` (census / ternary census, ``asp_sgm`` /
+    ``asp_mgm``). The SGM/MGM correlator converts each tile to uint8 with a
+    per-tile min-max stretch, so skipping the global normalization does not
+    change the integer disparity. Note that with this option an orthoimage
+    produced by ``point2dem --orthoimage`` carries the raw input pixel values
+    rather than normalized values; the DEM geometry is unaffected.
           
 nodata-value (default = NaN)
     Pixels with values less than or equal to this number are treated as

--- a/src/asp/Core/FileUtils.cc
+++ b/src/asp/Core/FileUtils.cc
@@ -22,6 +22,8 @@
 #include <vw/Cartography/GeoReference.h>
 #include <vw/Core/Log.h>
 
+#include <gdal.h>
+
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
@@ -469,8 +471,36 @@ void read_matrix_from_string(std::string const& str,
   convertToVec3(raw, mat);
 }
 
+// For a VRT input, write a re-serialized copy rather than a symlink.
+// The GDAL VRT driver canonicalizes the source paths stored inside the
+// VRT (to absolute) for the new location, which makes the run
+// self-contained and independent of how a given GDAL version resolves
+// relative source paths through a symlink. The copy is metadata-only
+// (VRT XML); no pixels are read or written.
+static void materializeVrt(std::string const& input_file,
+                           std::string const& output_file) {
+
+  GDALDatasetH in_ds = GDALOpen(input_file.c_str(), GA_ReadOnly);
+  if (in_ds == NULL)
+    vw::vw_throw(vw::ArgumentErr() << "Cannot open: " << input_file << ".\n");
+
+  GDALDriverH drv = GDALGetDriverByName("VRT");
+  GDALDatasetH out_ds = GDALCreateCopy(drv, output_file.c_str(), in_ds,
+                                       FALSE, NULL, NULL, NULL);
+  if (out_ds == NULL) {
+    GDALClose(in_ds);
+    vw::vw_throw(vw::ArgumentErr() << "Failed to write: " << output_file << ".\n");
+  }
+
+  GDALClose(out_ds);
+  GDALClose(in_ds);
+  vw::vw_out() << "Wrote: " << output_file << " (re-serialized VRT copy of "
+               << input_file << ")\n";
+}
+
 // Create symlinks to the input images for skip_image_normalization mode.
-// The symlinks are relative to the output directory.
+// The symlinks are relative to the output directory. VRT inputs are
+// copied (re-serialized) rather than symlinked; see materializeVrt().
 void createSymLinks(std::string const& left_input_file,
                     std::string const& right_input_file,
                     std::string const& out_prefix,
@@ -483,19 +513,27 @@ void createSymLinks(std::string const& left_input_file,
   right_output_file = out_prefix + "-R.tif";
 
   if (!fs::exists(left_output_file)) {
-    fs::path out_dir = fs::path(out_prefix).parent_path();
-    fs::path left_rel = out_dir.empty() ? fs::path(left_input_file) :
-                        vw::make_file_relative_to_dir(fs::path(left_input_file), out_dir);
-    fs::create_symlink(left_rel, left_output_file);
-    vw::vw_out() << "Created symlink: " << left_output_file << " -> " << left_rel << "\n";
+    if (vw::get_extension(left_input_file) == ".vrt") {
+      materializeVrt(left_input_file, left_output_file);
+    } else {
+      fs::path out_dir = fs::path(out_prefix).parent_path();
+      fs::path left_rel = out_dir.empty() ? fs::path(left_input_file) :
+                          vw::make_file_relative_to_dir(fs::path(left_input_file), out_dir);
+      fs::create_symlink(left_rel, left_output_file);
+      vw::vw_out() << "Created symlink: " << left_output_file << " -> " << left_rel << "\n";
+    }
   }
 
   if (!fs::exists(right_output_file)) {
-    fs::path out_dir = fs::path(out_prefix).parent_path();
-    fs::path right_rel = out_dir.empty() ? fs::path(right_input_file) :
-                         vw::make_file_relative_to_dir(fs::path(right_input_file), out_dir);
-    fs::create_symlink(right_rel, right_output_file);
-    vw::vw_out() << "Created symlink: " << right_output_file << " -> " << right_rel << "\n";
+    if (vw::get_extension(right_input_file) == ".vrt") {
+      materializeVrt(right_input_file, right_output_file);
+    } else {
+      fs::path out_dir = fs::path(out_prefix).parent_path();
+      fs::path right_rel = out_dir.empty() ? fs::path(right_input_file) :
+                           vw::make_file_relative_to_dir(fs::path(right_input_file), out_dir);
+      fs::create_symlink(right_rel, right_output_file);
+      vw::vw_out() << "Created symlink: " << right_output_file << " -> " << right_rel << "\n";
+    }
   }
 }
 

--- a/src/asp/Tools/stereo.cc
+++ b/src/asp/Tools/stereo.cc
@@ -190,19 +190,26 @@ bool skip_image_normalization(ASPGlobalOptions const& opt) {
   bool scale_invariant_cost = (stereo_settings().cost_mode == 2 ||
                                stereo_settings().cost_mode == 3 ||
                                stereo_settings().cost_mode == 4);
+  // Any GDAL-supported image format works here: the {prefix}-L.tif and
+  // {prefix}-R.tif outputs are read back through GDAL, which identifies
+  // rasters by content rather than by the file name. VRT inputs are
+  // re-serialized rather than symlinked, which canonicalizes their
+  // internal source paths for the run directory (see materializeVrt()
+  // in FileUtils.cc).
   bool is_good = (!crop_left && !crop_right                    &&
                   stereo_settings().alignment_method == "none" &&
                   scale_invariant_cost                         &&
                   !asp::doBathy(asp::stereo_settings())        &&
-                  vw::has_tif_or_ntf_extension(opt.in_file1)   &&
-                  vw::has_tif_or_ntf_extension(opt.in_file2));
+                  vw::has_image_extension(opt.in_file1)        &&
+                  vw::has_image_extension(opt.in_file2));
 
   if (!is_good)
     vw_throw(ArgumentErr()
               << "Cannot skip image normalization unless there is no alignment, "
               << "no use of --left-image-crop-win and --right-image-crop-win, "
               << "no bathymetry, --cost-mode is set to 2, 3, or 4, and the input "
-              << "images have .tif or .ntf extension.");
+              << "images have a supported image extension (such as .tif, .ntf, "
+              << "or .vrt).");
 
   return is_good;
 } // End function skip_image_normalization

--- a/src/asp/Tools/stereo.cc
+++ b/src/asp/Tools/stereo.cc
@@ -168,7 +168,8 @@ void saveRunInfo(ASPGlobalOptions const& opt,
 
 // See if user's request to skip image normalization can be
 // satisfied.  This option is a speedup switch which is only meant
-// to work with with mapprojected images. It is also not documented.
+// to work with mapprojected images. See the skip-image-normalization
+// entry in stereodefault.rst for the supported conditions.
 bool skip_image_normalization(ASPGlobalOptions const& opt) {
 
   if (!stereo_settings().skip_image_normalization)
@@ -179,9 +180,19 @@ bool skip_image_normalization(ASPGlobalOptions const& opt) {
 
   // Respect user's choice for skipping the normalization of the input
   // images, if feasible.
+  // Cost modes 2 (NCC), 3 (census), and 4 (ternary census) are invariant
+  // to a linear scaling of the inputs: NCC normalizes by construction,
+  // and the SGM/MGM path converts each tile to uint8 with a per-tile
+  // min-max stretch (u8_convert in VW ImageThresh.h) that produces
+  // identical output for any linearly pre-scaled input. Only cost modes
+  // 0/1 (absolute/squared differences) genuinely require the global
+  // normalization performed by stereo_pprc.
+  bool scale_invariant_cost = (stereo_settings().cost_mode == 2 ||
+                               stereo_settings().cost_mode == 3 ||
+                               stereo_settings().cost_mode == 4);
   bool is_good = (!crop_left && !crop_right                    &&
                   stereo_settings().alignment_method == "none" &&
-                  stereo_settings().cost_mode == 2             &&
+                  scale_invariant_cost                         &&
                   !asp::doBathy(asp::stereo_settings())        &&
                   vw::has_tif_or_ntf_extension(opt.in_file1)   &&
                   vw::has_tif_or_ntf_extension(opt.in_file2));
@@ -190,8 +201,8 @@ bool skip_image_normalization(ASPGlobalOptions const& opt) {
     vw_throw(ArgumentErr()
               << "Cannot skip image normalization unless there is no alignment, "
               << "no use of --left-image-crop-win and --right-image-crop-win, "
-              << "no bathymetry, --cost-mode is set to 2, and the input images have "
-              << ".tif or .ntf extension.");
+              << "no bathymetry, --cost-mode is set to 2, 3, or 4, and the input "
+              << "images have .tif or .ntf extension.");
 
   return is_good;
 } // End function skip_image_normalization


### PR DESCRIPTION
Closes #492, closes #493. Two commits, one per issue.

**1. Allow census cost modes (3, 4)** — the guard required `--cost-mode 2`, which made the option unusable with `asp_sgm`/`asp_mgm` (census modes are SGM-only). Census costs are invariant to a linear scaling of the inputs, and the SGM/MGM correlator converts every tile to uint8 with a per-tile min-max stretch (`u8_convert` in VW's ImageThresh.h) that produces identical output for any linearly pre-scaled input — `stereo_pprc`'s global normalization (a non-clamping affine map) is therefore redundant for these modes. The value-sensitive `stereo_rfne` subpixel modes (2, 3) already re-normalize on the fly in skip mode, so no refinement path is affected. Only cost modes 0/1 genuinely require the normalization.

**2. Accept any supported input format** — the option also required `.tif`/`.ntf` extensions. The `{prefix}-L.tif` / `{prefix}-R.tif` outputs are read back through GDAL, which identifies rasters by content, so the check now uses `vw::has_image_extension` (the predicate ASP uses elsewhere for image arguments). This notably admits `.vrt`, letting large mapprojected images be windowed to the stereo pair's intersection or mosaicked virtually with no pixel copies. VRT inputs are materialized as a re-serialized copy (GDAL VRT driver `CreateCopy` — metadata-only) instead of symlinked, which canonicalizes the source paths stored inside the VRT for the new location and makes the run self-contained.

**Validation**
- Live run (large mapprojected pair, `alignment-method none`, `asp_mgm`) on the current release: `stereo_pprc` correctly creates the L/R symlinks and the guard then aborts — the exact case this PR unlocks.
- GDAL-level test of the VRT materialization (GDAL 3.10.1): `CreateCopy` of a windowed VRT preserves windowing/georeference/nodata and pixel checksums, writes absolute source paths, and is a ~2 KB metadata-only write.
- Both changes are validation-gate/pprc-level; no correlation code is touched.

**Notes for review**
- `vw::has_image_extension` includes `.cub`; skip mode was previously unreachable for ISIS inputs, so that path is admitted-but-untested here (reads go through GDAL by content; multi-band inputs are still rejected independently). Happy to narrow the predicate if preferred.
- The docs entry now spells out the full supported conditions, including that `point2dem --orthoimage` output carries raw input values under this option (DEM geometry unaffected).
- No unit test added (no existing coverage of this path); a disparity-parity pair test (skip vs no-skip, `asp_mgm` cost-mode 4) is easy to add to the external test suite if desired.
