### PR TITLE
Accept GDAL virtual file system paths in pc_align, n_align, and point2dem

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -134,6 +134,10 @@ Misc:
   * The reader for DigitalGlobe/WorldView camera XML now handles the new
     namespaced Vantor/Maxar ISD metadata, with ``lv1b:`` and ``isdc:`` tag
     prefixes (:numref:`dg_tutorial`).
+  * ``pc_align``, ``n_align``, and ``point2dem`` now accept GDAL virtual file
+    system paths, such as ``/vsizip/``, ``/vsitar/``, and ``/vsicurl/``, so a
+    cloud or DEM can be read from an archive without extracting it
+    (:numref:`pc_align`).
 
 RELEASE 3.7.0, June 2026
 ------------------------

--- a/docs/tools/pc_align.rst
+++ b/docs/tools/pc_align.rst
@@ -417,6 +417,13 @@ format (the output of ``parallel_stereo``, :numref:`outputfiles`), DEMs as
 GeoTIFF or ISIS cub files, LAS files (including LAZ and COPC), or plain-text CSV
 files (with .csv or .txt extension).
 
+A GDAL-readable input can also be given as a GDAL virtual file system path, such
+as ``/vsizip/path/to/data.zip/cloud.tif`` or ``/vsicurl/https://host/dem.tif``,
+so a cloud or DEM is read from an archive without extracting it, or over the
+network. This does not apply to LAS and CSV inputs, which are not read with
+GDAL. A ``/vsicurl`` URL carrying a query string (such as a signed URL) is not
+supported, as the format is deduced from the file extension.
+
 .. _pc_align_csv:
 
 CSV

--- a/src/asp/Core/FileUtils.cc
+++ b/src/asp/Core/FileUtils.cc
@@ -23,6 +23,7 @@
 #include <vw/Core/Log.h>
 
 #include <gdal.h>
+#include <cpl_vsi.h>
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -36,6 +37,20 @@
 namespace fs = boost::filesystem;
 
 namespace asp {
+
+  // Return true if this is a GDAL virtual file system path, such as /vsizip/.
+  bool isVsiPath(std::string const& file) {
+    return (file.rfind("/vsi", 0) == 0); // the GDAL prefix is case-sensitive
+  }
+
+  // Return true if this file exists, local or a GDAL virtual file system path.
+  // Only existence is queried, so no data is fetched for a remote path.
+  bool fileExists(std::string const& file) {
+    if (!isVsiPath(file))
+      return fs::exists(file);
+    VSIStatBufL stat_buf;
+    return (VSIStatExL(file.c_str(), &stat_buf, VSI_STAT_EXISTS_FLAG) == 0);
+  }
 
   // Return true if the first file exists and is newer than all of the other files.
   bool first_is_newer(std::string              const& test_file, 

--- a/src/asp/Core/FileUtils.h
+++ b/src/asp/Core/FileUtils.h
@@ -25,6 +25,14 @@
 
 namespace asp {
 
+  // Return true if this is a GDAL virtual file system path, such as /vsizip/,
+  // /vsitar/, or /vsicurl/. Such a path is read by GDAL, not as a local file.
+  bool isVsiPath(std::string const& file);
+
+  // Return true if this file exists. Unlike boost::filesystem::exists(), this
+  // also works for GDAL virtual file system paths.
+  bool fileExists(std::string const& file);
+
   /// Return true if the first file exists and is newer than all of the other files.
   /// - Also returns false if any files are missing.
   /// - If a blank "" file is passed in it is ignored.

--- a/src/asp/Core/PointToDem.cc
+++ b/src/asp/Core/PointToDem.cc
@@ -18,6 +18,7 @@
 #include <asp/Core/PointToDem.h>
 #include <asp/Core/PointUtils.h>
 #include <asp/Core/PointCloudProcessing.h>
+#include <asp/Core/FileUtils.h>
 #include <asp/Core/PdalUtils.h>
 #include <asp/Core/CartographyUtils.h>
 #include <vw/FileIO/DiskImageUtils.h>
@@ -67,7 +68,8 @@ void parse_input_clouds_textures(std::vector<std::string> const& files,
   for (int i = 0; i < num; i++) {
     if (asp::is_las(files[i]) && pdal::Utils::isRemote(files[i]))
       continue; // This is a remote file, so we don't check existence
-    if (!fs::exists(files[i]))
+    // Unlike fs::exists(), this also sees a GDAL virtual file system path.
+    if (!asp::fileExists(files[i]))
       vw_throw(ArgumentErr() << "File does not exist: " << files[i] << ".\n");
   }
 

--- a/src/asp/Core/tests/TestFileUtils.cxx
+++ b/src/asp/Core/tests/TestFileUtils.cxx
@@ -1,0 +1,62 @@
+// __BEGIN_LICENSE__
+//  Copyright (c) 2009-2026, United States Government as represented by the
+//  Administrator of the National Aeronautics and Space Administration. All
+//  rights reserved.
+//
+//  The NGT platform is licensed under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance with the
+//  License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// __END_LICENSE__
+
+#include <test/Helpers.h>
+#include <asp/Core/FileUtils.h>
+
+#include <cpl_vsi.h>
+
+using namespace asp;
+
+TEST(FileUtils, isVsiPath) {
+
+  // GDAL virtual file systems
+  EXPECT_TRUE(asp::isVsiPath("/vsizip/data.zip/cloud.tif"));
+  EXPECT_TRUE(asp::isVsiPath("/vsitar//home/user/data.tar/cloud.tif"));
+  EXPECT_TRUE(asp::isVsiPath("/vsicurl/https://example.com/cloud.tif"));
+  EXPECT_TRUE(asp::isVsiPath("/vsis3/bucket/cloud.tif"));
+
+  // Ordinary local paths, including ones that merely mention vsi
+  EXPECT_FALSE(asp::isVsiPath("cloud.tif"));
+  EXPECT_FALSE(asp::isVsiPath("/home/user/cloud.tif"));
+  EXPECT_FALSE(asp::isVsiPath("/home/user/vsizip/cloud.tif"));
+  EXPECT_FALSE(asp::isVsiPath("vsizip/cloud.tif")); // must be absolute
+  EXPECT_FALSE(asp::isVsiPath(""));
+
+  // GDAL matches these prefixes case-sensitively, so this is a local path
+  EXPECT_FALSE(asp::isVsiPath("/VSIZIP/data.zip/cloud.tif"));
+}
+
+TEST(FileUtils, fileExists) {
+
+  // A local file that exists. TEST_SRCDIR is this file's directory, so the
+  // check does not depend on the directory the test is run from.
+  EXPECT_TRUE(asp::fileExists(std::string(TEST_SRCDIR) + "/TestFileUtils.cxx"));
+  EXPECT_FALSE(asp::fileExists("no_such_file_should_ever_exist.tif"));
+
+  // A virtual path, exercising the GDAL branch in both directions. /vsimem/ is
+  // in-memory, so this touches neither the disk nor the network.
+  const char* mem_file = "/vsimem/test_file_utils.bin";
+  VSIFCloseL(VSIFOpenL(mem_file, "wb"));
+  EXPECT_TRUE(asp::fileExists(mem_file));
+  VSIUnlink(mem_file);
+  EXPECT_FALSE(asp::fileExists(mem_file));
+
+  // A virtual path whose archive does not exist must be false, not an error
+  EXPECT_FALSE(asp::fileExists("/vsizip/no_such_archive.zip/cloud.tif"));
+  EXPECT_FALSE(asp::fileExists("/vsitar/no_such_archive.tar/cloud.tif"));
+}

--- a/src/asp/PcAlign/pc_align_utils.cc
+++ b/src/asp/PcAlign/pc_align_utils.cc
@@ -21,6 +21,7 @@
 #include <asp/PcAlign/pc_align_utils.h>
 #include <asp/Core/EigenUtils.h>
 #include <asp/Core/PointUtils.h>
+#include <asp/Core/FileUtils.h>
 #include <asp/Core/PointCloudRead.h>
 #include <asp/Core/PdalUtils.h>
 
@@ -85,9 +86,15 @@ void load_cloud_as_mat(std::string const& file_name,
   if (verbose)
     vw::vw_out() << "Reading: " << file_name << std::endl;
 
-  // Remote files should not be checked for existence
-  if (!asp::is_las(file_name) || !pdal::Utils::isRemote(file_name))
+  // A remote file is not checked against the local filesystem. Remote LAS is
+  // fetched by PDAL. A GDAL virtual file system path cannot be opened by
+  // validateFile(), which uses std::ifstream, so it is checked with GDAL.
+  if (asp::isVsiPath(file_name)) {
+    if (!asp::fileExists(file_name))
+      vw::vw_throw(vw::ArgumentErr() << "File does not exist: " << file_name << ".\n");
+  } else if (!asp::is_las(file_name) || !pdal::Utils::isRemote(file_name)) {
     PointMatcherSupport::validateFile(file_name);
+  }
 
   // We will over-write this below for CSV and DEM files where
   // longitude is available.

--- a/src/asp/Tools/pc_align.cc
+++ b/src/asp/Tools/pc_align.cc
@@ -969,7 +969,7 @@ vw::Vector3 estimate_ref_cloud_centroid(Options const& opt,
   Stopwatch sw;
   sw.start();
 
-  PointMatcherSupport::validateFile(reference);
+  // The reference file is validated in load_cloud(), called below.
   PointMatcher<double>::DataPoints points;
 
   double median_longitude = 0.0; // to convert back from xyz to lonlat

--- a/src/asp/Tools/point2dem.cc
+++ b/src/asp/Tools/point2dem.cc
@@ -20,6 +20,7 @@
 
 #include <asp/Core/PointToDem.h>
 #include <asp/Core/PointUtils.h>
+#include <asp/Core/FileUtils.h>
 #include <asp/Core/OrthoRasterizer.h>
 #include <asp/Core/Macros.h>
 #include <asp/Core/AspProgramOptions.h>
@@ -296,7 +297,8 @@ void handle_arguments(int argc, char *argv[], DemOptions& opt) {
 
   if (opt.out_prefix.empty()) {
     std::string input_file = opt.pointcloud_files[0];
-    if (asp::is_las(input_file) && pdal::Utils::isRemote(input_file))
+    if ((asp::is_las(input_file) && pdal::Utils::isRemote(input_file)) ||
+        asp::isVsiPath(input_file))
      input_file = fs::path(input_file).filename().string(); // rm the remote path
     opt.out_prefix = asp::prefix_from_pointcloud_filename(input_file);
   }


### PR DESCRIPTION
**Title:** Accept GDAL virtual file system paths in pc_align, n_align, and point2dem

Fixes #498.

`pc_align`, `n_align`, and `point2dem` reject GDAL virtual file system paths
(`/vsizip/`, `/vsitar/`, `/vsicurl/`, …) because their inputs are checked against the
local filesystem before GDAL sees them. Other ASP tools already read such paths —
`dem_mosaic`, `image_calc`, `hillshade`, and `colormap` all work — and so does
everything downstream of these checks.

### Changes

Two helpers in `asp/Core/FileUtils`, beside the existing file utilities:

- `asp::isVsiPath()` — is this a `/vsi…` path
- `asp::fileExists()` — existence for local *and* virtual paths, via GDAL's
  `VSIStatExL`; plain `fs::exists()` for local paths, so no GDAL call is added to
  the common case

and their use at the input checks:

| File | Was | Now |
|---|---|---|
| `PcAlign/pc_align_utils.cc` | `validateFile()` unless remote LAS | also skip for `/vsi…`, checking existence with GDAL instead (covers `pc_align` and `n_align`) |
| `Core/PointToDem.cc` | `fs::exists()` | `asp::fileExists()` |
| `Tools/point2dem.cc` | output prefix derived from the input path | strip the path for `/vsi…` too, as is already done for remote LAS |
| `Tools/pc_align.cc` | a second `validateFile()` on the reference | removed — `load_cloud()` below already validates it, and unlike this call it correctly exempts remote LAS |

Local files behave exactly as before, including the error raised when a file is
genuinely missing. `estimate_ref_cloud_centroid` has a single caller and no branch
between the deleted line and `load_cloud()`, so the reference is still validated —
and that path, unlike the deleted one, exempts remote LAS, so
`--initial-ned-translation` with a remote `.las` reference now works too. `src/asp/Core/tests/TestFileUtils.cxx` covers the predicate and both
directions of the GDAL branch (via `/vsimem/`, so it touches neither disk nor
network).

The `point2dem.cc` change is needed because without it a `/vsi` input with no `-o`
builds an output prefix like `/vsizip/data.zip/cloud`, and `create_out_dir()` then
tries `create_directories("/vsizip/data.zip")` at the filesystem root.

### Validation

Built against master (`5c63bd32e`) on macOS arm64 and run:

```
$ pc_align --max-displacement -1 --num-iterations 5 \
    /vsizip/$PWD/real_pc.zip/real_pc.tif /vsizip/$PWD/real_pc.zip/real_pc.tif -o out
Reading: /vsizip//.../real_pc.zip/real_pc.tif
Number of errors: 4096                      # before: ERROR: Cannot open file

$ point2dem /vsizip/$PWD/pc.zip/pc.tif -o out
Writing: out-DEM.tif                        # before: ERROR: File does not exist

$ point2dem /vsizip/$PWD/real_pc.zip/real_pc.tif      # no -o
Writing log: real_pc-log-point2dem-....txt  # prefix is local; no /vsizip dir created

$ point2dem ./pc.tif -o out_local           # local input unchanged
Writing: out_local-DEM.tif

$ point2dem ./no_such.tif -o out            # missing file still errors
ERROR: File does not exist: .../no_such.tif.

$ ./AspCore_TestFileUtils
[  PASSED  ] 2 tests.
```

The test file is picked up by the existing `get_all_source_files("Core/tests" ...)`
glob, so a fresh `cmake` run is needed for it to register.

### Notes for review

- `fileExists()` on a `/vsicurl` path does a network metadata query (existence only,
  no data). If you would rather argument checking never touch the network, I can
  restrict the existence test to the local virtual filesystems and let a remote path
  fall through to GDAL's own error on open.
- Not addressed, and documented rather than fixed: LAS and CSV inputs still go
  through PDAL and `std::ifstream`, so `/vsi` does not apply to them; and a
  `/vsicurl` URL with a query string (a signed URL) fails earlier, in VW's
  extension-based format dispatch.
- Happy to narrow this to `pc_align` alone if you prefer a smaller change, though
  `point2dem` fails the same way for the same reason.

Drafted with assistance from Claude; the patch and its validation are my own.