### PR TITLE
stereo_gui: option to preserve input dtype in image pyramids

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -120,6 +120,12 @@ n_align (:numref:`n_align`):
   * Added support for LAZ COPC files, with the ``--copc-win`` and
     ``--copc-read-all`` options, as in ``pc_align``.
 
+stereo_gui (:numref:`stereo_gui`):
+  * Added ``--preserve-input-pyramid-dtype``, to build the image pyramid of a
+    single-band UInt8 or UInt16 input with its native data type instead of
+    Float32, so the ``_subN.tif`` files keep the input's semantic type and
+    take less space on disk.
+
 Misc:
   * Fixed a bug with very long input image names when creating ``.match`` and
     ``.vwip`` file names (:numref:`match_file_naming`).

--- a/docs/tools/stereo_gui.rst
+++ b/docs/tools/stereo_gui.rst
@@ -905,6 +905,14 @@ accept all other ``parallel_stereo`` options as well.
     ``--hillshade``, also build the hillshaded images and their
     multi-resolution pyramids.
 
+--preserve-input-pyramid-dtype
+    When building image pyramids for single-band images, write the
+    subsampled levels (the ``_subN.tif`` files) using the input pixel
+    data type (currently ``UInt8`` or ``UInt16``) instead of always
+    converting to ``Float32``. This preserves the semantic data type
+    and reduces the size of the pyramid files for integer inputs. Has
+    no effect for multi-band images or floating-point inputs.
+
 --threads <integer (default: 0)>
     Select the number of threads to use for each process. If 0, use
     the value in ~/.vwrc.

--- a/src/asp/Core/StereoSettings.cc
+++ b/src/asp/Core/StereoSettings.cc
@@ -593,6 +593,8 @@ GUIDescription::GUIDescription(): po::options_description("GUI options") {
       "Delete any subsampled and other files created by the GUI when exiting.")
     ("create-image-pyramids-only", po::bool_switch(&global.create_image_pyramids_only)->default_value(false)->implicit_value(true),
       "Without starting the GUI, build multi-resolution pyramids for the inputs, to be able to load them fast later.")
+    ("preserve-input-pyramid-dtype", po::bool_switch(&global.preserve_input_pyramid_dtype)->default_value(false)->implicit_value(true),
+      "When building image pyramids for single-band images, write the subsampled levels using the input pixel data type (currently UInt8 or UInt16) instead of always converting to Float32. This preserves the semantic data type and reduces the size of the pyramid files for integer inputs. Has no effect for multi-band or floating-point images.")
     ("pairwise-matches", po::bool_switch(&global.pairwise_matches)->default_value(false)->implicit_value(true), "Show images side-by-side. If just two of them are selected, load their corresponding match file, determined by the output prefix. Also accessible from the menu.")
     ("pairwise-clean-matches", po::bool_switch(&global.pairwise_clean_matches)->default_value(false)->implicit_value(true), "Same as --pairwise-matches, but use *-clean.match files.")
     ("nvm", po::value(&global.nvm)->default_value(""),

--- a/src/asp/Core/StereoSettings.h
+++ b/src/asp/Core/StereoSettings.h
@@ -263,6 +263,7 @@ namespace asp {
     std::string match_file, gcp_file, dem_file, csv_datum, csv_format_str, csv_srs, nvm, isis_cnet;
     bool delete_temporary_files_on_exit;
     bool create_image_pyramids_only, hide_all, nvm_no_shift;
+    bool preserve_input_pyramid_dtype;
     bool pairwise_matches, pairwise_clean_matches, no_georef, zoom_all_to_same_region;
     std::vector<std::string> vwip_files;
     vw::BBox2 zoom_proj_win;

--- a/src/asp/GUI/DiskImagePyramidMultiChannel.cc
+++ b/src/asp/GUI/DiskImagePyramidMultiChannel.cc
@@ -180,7 +180,38 @@ DiskImagePyramidMultiChannel(std::string const& image_file,
     m_valid_min = valid_min;
     m_valid_max = valid_max;
 
-    if (m_num_channels == 1 || image_fmt.channel_type != VW_CHANNEL_UINT8) {
+    // Opt-in (--preserve-input-pyramid-dtype): for a single-band integer image,
+    // build the pyramid using the native integer pixel type so the subsampled
+    // _subN.tif files keep the input data type (and are smaller) instead of
+    // always being promoted to Float32. Only UInt8 and UInt16 are handled here;
+    // any other single-band type (Int16, UInt32, floating point, ...) falls
+    // through to the Float32 path below. Display still works, as the integer
+    // clip is converted to double in get_image_clip().
+    bool preserve_dtype = asp::stereo_settings().preserve_input_pyramid_dtype;
+
+    if (m_num_channels == 1 && preserve_dtype &&
+        image_fmt.channel_type == VW_CHANNEL_UINT8) {
+      // Single channel image with uint8 pixels.
+      m_img_ch1_uint8 =
+        vw::mosaic::DiskImagePyramid<vw::uint8>(image_file, m_opt, lowres_size,
+                                                2, valid_min, valid_max);
+      m_rows = m_img_ch1_uint8.rows();
+      m_cols = m_img_ch1_uint8.cols();
+      m_type = CH1_UINT8;
+      temporary_files().files.insert(m_img_ch1_uint8.get_temporary_files().begin(),
+                                     m_img_ch1_uint8.get_temporary_files().end());
+    } else if (m_num_channels == 1 && preserve_dtype &&
+               image_fmt.channel_type == VW_CHANNEL_UINT16) {
+      // Single channel image with uint16 pixels.
+      m_img_ch1_uint16 =
+        vw::mosaic::DiskImagePyramid<vw::uint16>(image_file, m_opt, lowres_size,
+                                                 2, valid_min, valid_max);
+      m_rows = m_img_ch1_uint16.rows();
+      m_cols = m_img_ch1_uint16.cols();
+      m_type = CH1_UINT16;
+      temporary_files().files.insert(m_img_ch1_uint16.get_temporary_files().begin(),
+                                     m_img_ch1_uint16.get_temporary_files().end());
+    } else if (m_num_channels == 1 || image_fmt.channel_type != VW_CHANNEL_UINT8) {
       // Single channel image with float pixels.
 
       m_img_ch1_float =
@@ -237,6 +268,10 @@ double DiskImagePyramidMultiChannel::get_nodata_val() const {
   // Extract the clip, then convert it from VW format to QImage format.
   if (m_type == CH1_FLOAT) {
     return m_img_ch1_float.get_nodata_val();
+  } else if (m_type == CH1_UINT8) {
+    return m_img_ch1_uint8.get_nodata_val();
+  } else if (m_type == CH1_UINT16) {
+    return m_img_ch1_uint16.get_nodata_val();
   } else if (m_type == CH2_UINT8) {
     return m_img_ch2_uint8.get_nodata_val();
   } else if (m_type == CH3_UINT8) {
@@ -248,6 +283,47 @@ double DiskImagePyramidMultiChannel::get_nodata_val() const {
   }
 }
 
+// Shared logic for rendering a single-channel pyramid (float, uint8, or
+// uint16) to a QImage. The extracted clip is converted to double inside
+// formQimageFloat, so integer and float pyramids display identically.
+template<class PyramidT>
+void formSingleChannelQimage(PyramidT const& pyramid,
+                             double scale_in, vw::BBox2i region_in,
+                             bool highlight_nodata,
+                             vw::Colormap const* colormap,
+                             vw::Vector2 const& bounds_override,
+                             float valid_min, float valid_max,
+                             QImage & qimg, double & scale_out,
+                             vw::BBox2i & region_out) {
+
+  vw::Vector2 approx_bounds;
+  if (bounds_override[0] < bounds_override[1]) {
+    // Use the caller-provided bounds (joint min/max or user --min/--max)
+    approx_bounds = bounds_override;
+  } else if (asp::stereo_settings().min < asp::stereo_settings().max) {
+    // If the min and max are set, not NaN, and first is less than the second
+    approx_bounds = vw::Vector2(asp::stereo_settings().min,
+                                asp::stereo_settings().max);
+  } else {
+    // Normally these are auto-estimated rather well, except for images with
+    // most data being very small, like in shadow.
+    approx_bounds = pyramid.approx_bounds();
+  }
+
+  // Ensure the bounds are always distinct
+  if (approx_bounds[0] >= approx_bounds[1] &&
+      approx_bounds[1] > -std::numeric_limits<double>::max())
+    approx_bounds[0] = approx_bounds[1] - 1.0;
+
+  vw::ImageView<typename PyramidT::pixel_type> clip;
+  pyramid.get_image_clip(scale_in, region_in, clip, scale_out, region_out);
+
+  // The clip is converted from its pixel type to double here (implicit).
+  formQimageFloat(highlight_nodata, pyramid.get_nodata_val(),
+                  valid_min, valid_max,
+                  approx_bounds, clip, colormap, qimg);
+}
+
 void DiskImagePyramidMultiChannel::get_image_clip(double scale_in,
                   vw::BBox2i region_in,
                   bool highlight_nodata,
@@ -256,48 +332,19 @@ void DiskImagePyramidMultiChannel::get_image_clip(double scale_in,
                   QImage & qimg, double & scale_out,
                   vw::BBox2i & region_out) const {
 
-  vw::Vector2 approx_bounds;
-
   // Extract the clip, then convert it from VW format to QImage format.
   if (m_type == CH1_FLOAT) {
-
-    //Stopwatch sw0;
-    //sw0.start();
-    if (bounds_override[0] < bounds_override[1]) {
-      // Use the caller-provided bounds (joint min/max or user --min/--max)
-      approx_bounds = bounds_override;
-    } else if (asp::stereo_settings().min < asp::stereo_settings().max) {
-      // If the min and max are set, not NaN, and first is less than the second
-      approx_bounds = vw::Vector2(asp::stereo_settings().min,
-                                  asp::stereo_settings().max);
-    } else {
-      // Normally these are auto-estimated rather well, except for images with
-      // most data being very small, like in shadow.
-      approx_bounds = m_img_ch1_float.approx_bounds();
-    }
-
-    // Ensure the bounds are always distinct
-    if (approx_bounds[0] >= approx_bounds[1] &&
-        approx_bounds[1] > -std::numeric_limits<double>::max())
-      approx_bounds[0] = approx_bounds[1] - 1.0;
-
-    //sw0.stop();
-    //vw_out() << "Render time sw0 (seconds): " << sw0.elapsed_seconds() << std::endl;
-
-    ImageView<float> clip;
-    //Stopwatch sw1;
-    //sw1.start();
-    m_img_ch1_float.get_image_clip(scale_in, region_in, clip, scale_out, region_out);
-    //sw1.stop();
-    //vw_out() << "Render time sw1 (seconds): " << sw1.elapsed_seconds() << std::endl;
-
-    //Stopwatch sw2;
-    //sw2.start();
-    formQimageFloat(highlight_nodata, m_img_ch1_float.get_nodata_val(),
-                    m_valid_min, m_valid_max,
-                    approx_bounds, clip, colormap, qimg);
-    //sw2.stop();
-    //vw_out() << "Render time sw2 (seconds): " << sw2.elapsed_seconds() << std::endl;
+    formSingleChannelQimage(m_img_ch1_float, scale_in, region_in,
+                            highlight_nodata, colormap, bounds_override,
+                            m_valid_min, m_valid_max, qimg, scale_out, region_out);
+  } else if (m_type == CH1_UINT8) {
+    formSingleChannelQimage(m_img_ch1_uint8, scale_in, region_in,
+                            highlight_nodata, colormap, bounds_override,
+                            m_valid_min, m_valid_max, qimg, scale_out, region_out);
+  } else if (m_type == CH1_UINT16) {
+    formSingleChannelQimage(m_img_ch1_uint16, scale_in, region_in,
+                            highlight_nodata, colormap, bounds_override,
+                            m_valid_min, m_valid_max, qimg, scale_out, region_out);
   } else if (m_type == CH2_UINT8) {
 
     ImageView<Vector<vw::uint8, 2>> clip;
@@ -355,6 +402,11 @@ std::string DiskImagePyramidMultiChannel::get_value_as_str(int32 x, int32 y) con
   std::ostringstream os;
   if (m_type == CH1_FLOAT) {
     os << m_img_ch1_float.bottom()(x, y, 0);
+  } else if (m_type == CH1_UINT8) {
+    // Cast to int so the uint8 value prints as a number, not a character.
+    os << int(m_img_ch1_uint8.bottom()(x, y, 0));
+  } else if (m_type == CH1_UINT16) {
+    os << m_img_ch1_uint16.bottom()(x, y, 0);
   } else if (m_type == CH2_UINT8) {
     os << Vector2(m_img_ch2_uint8.bottom()(x, y, 0));
   } else if (m_type == CH3_UINT8) {
@@ -371,6 +423,10 @@ std::string DiskImagePyramidMultiChannel::get_value_as_str(int32 x, int32 y) con
 double DiskImagePyramidMultiChannel::get_value_as_double(int32 x, int32 y) const {
   if (m_type == CH1_FLOAT) {
     return m_img_ch1_float.bottom()(x, y, 0);
+  } else if (m_type == CH1_UINT8) {
+    return m_img_ch1_uint8.bottom()(x, y, 0);
+  } else if (m_type == CH1_UINT16) {
+    return m_img_ch1_uint16.bottom()(x, y, 0);
   } else if (m_type == CH2_UINT8) {
     return m_img_ch2_uint8.bottom()(x, y, 0)[0];
   } else {

--- a/src/asp/GUI/DiskImagePyramidMultiChannel.h
+++ b/src/asp/GUI/DiskImagePyramidMultiChannel.h
@@ -55,7 +55,8 @@ namespace vw {
 namespace asp {
 
   // The kinds of images we support
-  enum ImgType {UNINIT, CH1_FLOAT, CH2_UINT8, CH3_UINT8, CH4_UINT8};
+  enum ImgType {UNINIT, CH1_FLOAT, CH1_UINT8, CH1_UINT16,
+                CH2_UINT8, CH3_UINT8, CH4_UINT8};
 
   // A global structure to hold all the temporary files we have created
   struct TemporaryFiles {
@@ -73,6 +74,10 @@ namespace asp {
   struct DiskImagePyramidMultiChannel {
     vw::GdalWriteOptions m_opt;
     vw::mosaic::DiskImagePyramid<float>                m_img_ch1_float;
+    // Single-channel integer pyramids, used only with
+    // --preserve-input-pyramid-dtype (see the constructor).
+    vw::mosaic::DiskImagePyramid<vw::uint8>            m_img_ch1_uint8;
+    vw::mosaic::DiskImagePyramid<vw::uint16>           m_img_ch1_uint16;
     vw::mosaic::DiskImagePyramid<vw::Vector<vw::uint8, 2>> m_img_ch2_uint8;
     vw::mosaic::DiskImagePyramid<vw::Vector<vw::uint8, 3>> m_img_ch3_uint8;
     vw::mosaic::DiskImagePyramid<vw::Vector<vw::uint8, 4>> m_img_ch4_uint8;

--- a/src/asp/GUI/ImageData.cc
+++ b/src/asp/GUI/ImageData.cc
@@ -516,9 +516,15 @@ vw::Vector2 calcJointBounds(std::vector<imageData> const& images,
       continue;
     }
     auto const& img = images[i].currentImg();
-    if (img.m_type != CH1_FLOAT)
-      continue;
-    vw::Vector2 ab = img.m_img_ch1_float.approx_bounds();
+    vw::Vector2 ab;
+    if (img.m_type == CH1_FLOAT)
+      ab = img.m_img_ch1_float.approx_bounds();
+    else if (img.m_type == CH1_UINT8)
+      ab = img.m_img_ch1_uint8.approx_bounds();
+    else if (img.m_type == CH1_UINT16)
+      ab = img.m_img_ch1_uint16.approx_bounds();
+    else
+      continue; // multi-channel uint8 maps directly to RGB, no min/max stretch
     bounds[0] = std::min(bounds[0], ab[0]);
     bounds[1] = std::max(bounds[1], ab[1]);
   }


### PR DESCRIPTION
`stereo_gui` (notably `--create-image-pyramids-only`) always builds a Float32 pyramid for single-band images; only multi-band uint8 keeps its type. For pipelines whose canonical inputs are the pyramid `_subN.tif` files of integer imagery (e.g. UInt16 scanned film frames), the primary cost is that the semantic data type of the dataset changes; the files also grow. Measured on a representative real scanned-film strip written with the default LZW compression, the Float32 pyramid chain is about 1.25x the size of the native UInt16 chain (30.6 vs 24.5 MB) and about 1.7x the native Byte chain (16.7 vs 9.6 MB); for uncompressed output the raw ratio is 2x and 4x respectively.

This adds `--preserve-input-pyramid-dtype` (default off, behavior unchanged for existing users). When set, a single-band UInt8 or UInt16 input builds a native-integer `DiskImagePyramid`; other single-band types (Int16/UInt32/float) still use Float32. Display is unaffected: the integer clip is converted to double before rendering, and the pixel-readout and joint-bounds paths handle the new single-band integer types. Docs and a NEWS entry are included.

Merge order: this requires the companion VisionWorkbench change (visionworkbench/visionworkbench#69) and does not compile without it. Since CI clones live VW master (`build_test.sh`), the VW PR needs to merge first for this PR's CI to pass.

Design notes, stated up front since they are fair questions. Only UInt8 and UInt16 get native pyramids: each additional `DiskImagePyramid<T>` instantiation measurably costs compile time and binary size (this translation unit went from ~18s to ~25s and its object file grew ~50% with the two added types, and that cost is paid by every build regardless of whether anyone uses the flag), so types with no known dataset (Int16, UInt32) are left on the Float32 fallback; extending is mechanical if a need appears. The implementation follows the file's existing per-type dispatch pattern (the same one the multi-band uint8 cases use), and the refactor shrinks the per-type cost of the render path by folding it into one `formSingleChannelQimage` template. Longer term, #138 proposes replacing this pyramid machinery with GDAL's own overview building, which preserves data types natively; this change is a small opt-in improvement to the machinery that exists today and becomes deletable if #138 lands.

Note on resampling: the anti-aliased downsample runs in double; the integer write truncates the fractional result (at most 1 DN, about -0.5 DN mean bias), identical to how the existing multi-band uint8 pyramids already behave. Round-to-nearest would also change those existing uint8 pyramids, so it is out of scope here.

A related cache hazard is fixed on the VW side: `overwrite_if_no_good()` previously reused an existing `_subN.tif` on matching size and mtime without checking its pixel type (channel type and band count), so toggling this option between runs against the same directory would silently reuse type-mismatched sub-files; it now regenerates them.

Testing: the GUI module has no existing gtest coverage, so verification is runtime, all passing on a local macOS arm64 build of this branch against the companion VW change: a 3-case dtype matrix via `--create-image-pyramids-only` (commands below), a 4-case nodata matrix and a boundary-averaging check of integer vs Float32 pyramids of the same image (detailed in the VW PR), and cache regeneration when the flag is toggled against an existing pyramid directory.

    gdal_create -ot UInt16 -outsize 4096 4096 -bands 1 -burn 12345 u16.tif
    stereo_gui --create-image-pyramids-only --preserve-input-pyramid-dtype u16.tif
    gdalinfo u16_sub2.tif | grep Type=   # UInt16 (Float32 without the flag)

